### PR TITLE
fix: Reorder initial fields in Join Us modal

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -197,6 +197,7 @@
         <div class="modal-body">
           <form id="join-form">
             <input type="text" name="contact_preference_notes" style="display:none !important; visibility:hidden !important; opacity:0 !important; position:absolute !important; left:-9999px !important; top:-9999px !important;" tabindex="-1" autocomplete="off">
+            <!-- Target Row 1: Name and Email -->
             <div class="form-row">
               <div class="form-cell">
                 <label for="join-name" data-en="Name" data-es="Nombre">Name</label>
@@ -207,24 +208,13 @@
                 <input type="email" id="join-email" placeholder="Enter your email / Ingrese su correo electrónico" required />
               </div>
             </div>
+            <!-- Target Row 2: Contact Number and Willing to Work -->
             <div class="form-row">
               <div class="form-cell">
                 <label for="join-contact" data-en="Contact Number" data-es="Número de Contacto">Contact Number</label>
                 <input type="tel" id="join-contact" placeholder="Enter your contact number / Ingrese su número" required />
               </div>
-            </div>
-            <div class="form-row">
-              <div class="form-cell">
-                <label for="join-interest" data-en="Interest in" data-es="Interés en">Interest in</label>
-                <select id="join-interest" name="join-interest" required>
-                  <option value="" data-en="Select an option..." data-es="Seleccione una opción...">Select an option...</option>
-                  <option value="business_operations" data-en="Business Operations" data-es="Gestión">Business Operations</option>
-                  <option value="contact_center" data-en="Contact Center" data-es="Centro de Servicios">Contact Center</option>
-                  <option value="it_support" data-en="IT Support" data-es="Soporte IT">IT Support</option>
-                  <option value="professionals" data-en="Professionals" data-es="Profesionales">Professionals</option>
-                </select>
-              </div>
-              <div class="form-cell" style="grid-column: 1 / -1;"> <!-- Spanning full width for the new section -->
+              <div class="form-cell"> <!-- Willing to Work section -->
                 <h4 class="collapsible-header">
                   <span data-en="Willing to Work" data-es="Disponibilidad Laboral">Willing to Work</span>
                   <span class="collapse-icon">+</span>
@@ -272,6 +262,20 @@
                   </div>
                 </div>
               </div>
+            </div>
+            <!-- Target Row 3: Interest in -->
+            <div class="form-row">
+              <div class="form-cell">
+                <label for="join-interest" data-en="Interest in" data-es="Interés en">Interest in</label>
+                <select id="join-interest" name="join-interest" required>
+                  <option value="" data-en="Select an option..." data-es="Seleccione una opción...">Select an option...</option>
+                  <option value="business_operations" data-en="Business Operations" data-es="Gestión">Business Operations</option>
+                  <option value="contact_center" data-en="Contact Center" data-es="Centro de Servicios">Contact Center</option>
+                  <option value="it_support" data-en="IT Support" data-es="Soporte IT">IT Support</option>
+                  <option value="professionals" data-en="Professionals" data-es="Profesionales">Professionals</option>
+                </select>
+              </div>
+              <div class="form-cell"></div> <!-- Empty cell for alignment -->
             </div>
             <div class="form-row">
               <div class="form-cell dynamic-section-wrapper" style="grid-column: 1 / -1;">

--- a/index.html
+++ b/index.html
@@ -146,24 +146,24 @@
         <div class="modal-body">
           <form id="join-form">
             <input type="text" name="contact_preference_notes" style="display:none !important; visibility:hidden !important; opacity:0 !important; position:absolute !important; left:-9999px !important; top:-9999px !important;" tabindex="-1" autocomplete="off">
-            <!-- New Row 1: Name and Contact Number -->
+            <!-- Target Row 1: Name and Email -->
             <div class="form-row">
               <div class="form-cell">
                 <label for="join-name" data-en="Name" data-es="Nombre">Name</label>
                 <input type="text" id="join-name" placeholder="Enter your name / Ingrese su Nombre" required />
               </div>
               <div class="form-cell">
-                <label for="join-contact" data-en="Contact Number" data-es="Número de Contacto">Contact Number</label>
-                <input type="tel" id="join-contact" placeholder="Enter your contact number / Ingrese su número" required />
-              </div>
-            </div>
-            <!-- New Row 2: Email and Willing to Work -->
-            <div class="form-row">
-              <div class="form-cell">
                 <label for="join-email" data-en="Email" data-es="Correo Electrónico">Email</label>
                 <input type="email" id="join-email" placeholder="Enter your email / Ingrese su correo electrónico" required />
               </div>
-              <div class="form-cell"> <!-- Removed style="grid-column: 1 / -1;" from Willing to Work wrapper -->
+            </div>
+            <!-- Target Row 2: Contact Number and Willing to Work -->
+            <div class="form-row">
+              <div class="form-cell">
+                <label for="join-contact" data-en="Contact Number" data-es="Número de Contacto">Contact Number</label>
+                <input type="tel" id="join-contact" placeholder="Enter your contact number / Ingrese su número" required />
+              </div>
+              <div class="form-cell"> <!-- Willing to Work section -->
                 <h4 class="collapsible-header">
                   <span data-en="Willing to Work" data-es="Disponibilidad Laboral">Willing to Work</span>
                   <span class="collapse-icon">+</span>
@@ -212,7 +212,7 @@
                 </div>
               </div>
             </div>
-            <!-- New Row 3: Interest in -->
+            <!-- Target Row 3: Interest in -->
             <div class="form-row">
               <div class="form-cell">
                 <label for="join-interest" data-en="Interest in" data-es="Interés en">Interest in</label>


### PR DESCRIPTION
This commit refactors the HTML structure for the initial fields (Name, Email, Contact Number, Willing to Work, Interest in) in the "Join Us" modal in both `index.html` and `about-us.html` as per your latest layout request.

New layout order:
- Row 1: Name (left cell) | Email (right cell)
- Row 2: Contact Number (left cell) | Willing to Work (collapsible, right cell)
- Row 3: Interest in (left cell) | Empty cell (right cell for alignment)

The "Willing to Work" section has had its full-width span removed and is now correctly placed in a standard grid cell.

Existing CSS (including `justify-content: flex-start` on form cells for vertical alignment and responsive stacking rules) is expected to handle this new layout without further modification.