### PR TITLE
Fix: Ensure chatbot modal is triggered by mobile launcher and FAB

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -160,7 +160,7 @@
     </button>
     <button class="mobile-nav-item" id="mobile-language-toggle" aria-label="Switch Language" title="Switch Language">EN</button>
     <button class="mobile-nav-item" id="mobile-theme-toggle" aria-label="Toggle Theme" title="Toggle Theme">Light</button>
-    <button class="mobile-nav-item" id="mobileChatLauncher" aria-label="Open Chat" title="Open Chat">
+    <button class="mobile-nav-item" id="mobileChatLauncher" data-modal="chatbot-modal" aria-label="Open Chat" title="Open Chat">
       <i class="fas fa-comment-alt"></i>
       <span>Chat</span>
     </button>


### PR DESCRIPTION
- Added `data-modal="chatbot-modal"` to the `mobileChatLauncher` button in `index.html` to enable it to trigger the chatbot modal.
- Reviewed CSS for the Floating Action Button (FAB) and found no issues that would cause it to be hidden. The FAB should be visible and functional.
- Both the mobile chat icon and the FAB should now correctly open the chatbot modal.