### PR TITLE
Add offline fallback page and update service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ const workerUrl = "https://your-worker.example.com"; // Cloudflare Worker endpoi
 
 Leave the value blank to disable submissions. When configured, the form’s data is sent via `POST` to the Worker which should handle the message (e.g. sending an email or storing the data).
 
+## Offline Caching
+
+The service worker pre-caches essential assets listed in `urlsToCache`, including a fallback `offline.html` page. If a network request fails, navigation requests return the offline page so the interface remains functional without connectivity.
+

--- a/js/service-worker.js
+++ b/js/service-worker.js
@@ -6,6 +6,7 @@ const CACHE_NAME = 'ops-solutions-v1';
 const urlsToCache = [
   '/',
   '/index.html',
+  '/offline.html',
   '/css/base/global.css',
   '/css/base/small-screens.css',
   '/js/pages/main.js'
@@ -64,8 +65,9 @@ self.addEventListener('fetch', event => {
       })
       .catch(error => {
         console.error('ServiceWorker: Fetch error:', error);
-        // Optional: Respond with a fallback page for offline if request fails
-        // return caches.match('/offline.html');
+        if (event.request.mode === 'navigate') {
+          return caches.match('/offline.html');
+        }
       })
   );
 });

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline - OPS Solutions Services</title>
+  <link rel="stylesheet" href="css/base/global.css">
+  <link rel="stylesheet" href="css/base/small-screens.css">
+</head>
+<body>
+  <main style="padding:2rem;text-align:center;">
+    <h1>You are offline</h1>
+    <p>The page you requested is unavailable. Please check your connection and try again.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a basic `offline.html` fallback page
- cache `offline.html` in the service worker
- return the offline page when a navigation request fails
- document caching and offline support in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f625b1774832b8a6db4f9cf466792