### PR TITLE
Fix service worker path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,13 @@ Leave the value blank to disable submissions. When configured, the form’s data
 
 The service worker pre-caches essential assets listed in `urlsToCache`, including a fallback `offline.html` page. If a network request fails, navigation requests return the offline page so the interface remains functional without connectivity.
 
+### Service Worker Path
+
+The registration call in `js/pages/main.js` registers the worker using:
+
+```javascript
+navigator.serviceWorker.register('js/service-worker.js');
+```
+
+This assumes the site is served from the root of your domain with the `js` directory at the same level as `index.html`. If your deployment differs, update the path accordingly so the service worker can be found.
+

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -429,7 +429,7 @@ document.addEventListener("DOMContentLoaded", () => {
        ================================================================= */
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-            navigator.serviceWorker.register('/js/service-worker.js')
+            navigator.serviceWorker.register('js/service-worker.js')
                 .then(reg => console.log('INFO:Main/ServiceWorker: Registered. Scope:', reg.scope))
                 .catch(err => console.error('ERROR:Main/ServiceWorker: Registration failed:', err));
         });


### PR DESCRIPTION
## Summary
- update the service worker registration path in `main.js`
- document the assumption about service worker path in the README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f89267508832b8c8e6e2eeebccd33