### PR TITLE
Improve mobile nav fallback

### DIFF
--- a/css/base/small-screens.css
+++ b/css/base/small-screens.css
@@ -160,10 +160,8 @@ on-guard/css/small-screens.css
     }
 
     /* Body padding to avoid overlap with fixed mobile nav (for index.html) */
-    /* This should only apply if .mobile-nav is visible */
-    body:has(.mobile-nav) {
-      /* :has selector might not be fully supported, JS fallback might be needed if issues */
-      /* For now, assuming this applies on pages with .mobile-nav like index.html */
+    /* Applied when JavaScript toggles .mobile-nav-active on <body> */
+    body.mobile-nav-active {
       padding-bottom: calc(var(--mobile-nav-base-height) + var(--mobile-nav-bottom-offset));
     }
 

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -8,6 +8,14 @@
 document.addEventListener("DOMContentLoaded", () => {
     console.log('INFO:Main/DOMContentLoaded: Initializing core functionalities.');
 
+    // Enable body padding adjustment for pages with a mobile nav
+    const mobileNavElement = document.querySelector('.mobile-nav');
+    if (mobileNavElement) {
+        document.body.classList.add('mobile-nav-active');
+    } else {
+        document.body.classList.remove('mobile-nav-active');
+    }
+
     /* ================================================================
        1) LANGUAGE TOGGLE (Desktop & Mobile for index.html header)
        ================================================================= */


### PR DESCRIPTION
## Summary
- use a JS fallback for mobile nav padding
- update CSS to rely on `.mobile-nav-active` instead of `:has()` selector

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f938a7be0832b88afd1fe881edf3c