### PR TITLE
Fix mobile nav support for browsers without :has()

### DIFF
--- a/css/base/small-screens.css
+++ b/css/base/small-screens.css
@@ -165,10 +165,13 @@ on-guard/css/small-screens.css
       padding-bottom: calc(var(--mobile-nav-base-height) + var(--mobile-nav-bottom-offset));
     }
 
-    /* Floating icons adjustments for mobile (for index.html) */
+    /* Floating icons adjustments for mobile when the nav bar is present */
     /* These values are from user's provided adaptable_screen.css */
-    .floating-icons {
+    body.mobile-nav-active .floating-icons {
         bottom: calc(var(--mobile-nav-base-height) + var(--mobile-nav-bottom-offset) + 0.5rem);
+    }
+
+    .floating-icons {
         right: 0.5rem;
         gap: 0.75rem;
         z-index: 999; /* Kept from global, ensures it's below modals/menus */

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -11,12 +11,15 @@ document.addEventListener("DOMContentLoaded", () => {
     console.log('INFO:Main/DOMContentLoaded: Initializing core functionalities.');
 
     // Enable body padding adjustment for pages with a mobile nav
-    const mobileNavElement = document.querySelector('.mobile-nav');
-    if (mobileNavElement) {
-        document.body.classList.add('mobile-nav-active');
-    } else {
-        document.body.classList.remove('mobile-nav-active');
+    function updateMobileNavStatus() {
+        const mobileNavElement = document.querySelector('.mobile-nav');
+        if (mobileNavElement) {
+            document.body.classList.add('mobile-nav-active');
+        } else {
+            document.body.classList.remove('mobile-nav-active');
+        }
     }
+    updateMobileNavStatus();
 
     /* ================================================================
        1) LANGUAGE TOGGLE (Desktop & Mobile for index.html header)


### PR DESCRIPTION
## Summary
- use `body.mobile-nav-active` in JavaScript when `.mobile-nav` exists
- adjust small‑screen styles to apply floating icon offset only when mobile nav is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f9cad58ec832b998a84b22a7bb343