### PR TITLE
Add service modals and dynamic loader

### DIFF
--- a/css/modals/business_operations_modal.css
+++ b/css/modals/business_operations_modal.css
@@ -1,0 +1,4 @@
+/* Modal styles specific to the Business Operations modal */
+#business-operations-modal .modal-content {
+  max-width: 600px;
+}

--- a/css/modals/contact_center_modal.css
+++ b/css/modals/contact_center_modal.css
@@ -1,0 +1,4 @@
+/* Modal styles specific to the Contact Center modal */
+#contact-center-modal .modal-content {
+  max-width: 600px;
+}

--- a/css/modals/it_support_modal.css
+++ b/css/modals/it_support_modal.css
@@ -1,0 +1,4 @@
+/* Modal styles specific to the IT Support modal */
+#it-support-modal .modal-content {
+  max-width: 600px;
+}

--- a/css/modals/professionals_modal.css
+++ b/css/modals/professionals_modal.css
@@ -1,0 +1,4 @@
+/* Modal styles specific to the Professionals modal */
+#professionals-modal .modal-content {
+  max-width: 600px;
+}

--- a/html/modals/business_operations_modal.html
+++ b/html/modals/business_operations_modal.html
@@ -1,0 +1,14 @@
+<div id="business-operations-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="boModalTitle" style="display: none;">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3 id="boModalTitle" data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</h3>
+      <button class="close-modal" data-close aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p data-en="Information about our business operations services." data-es="Informaci\u00f3n sobre nuestros servicios de operaciones empresariales.">Information about our business operations services.</p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="close-modal" data-close data-en="Close" data-es="Cerrar">Close</button>
+    </div>
+  </div>
+</div>

--- a/html/modals/contact_center_modal.html
+++ b/html/modals/contact_center_modal.html
@@ -1,0 +1,14 @@
+<div id="contact-center-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="ccModalTitle" style="display: none;">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3 id="ccModalTitle" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</h3>
+      <button class="close-modal" data-close aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p data-en="Learn about our contact center solutions." data-es="Conozca nuestras soluciones de centro de contacto.">Learn about our contact center solutions.</p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="close-modal" data-close data-en="Close" data-es="Cerrar">Close</button>
+    </div>
+  </div>
+</div>

--- a/html/modals/it_support_modal.html
+++ b/html/modals/it_support_modal.html
@@ -1,0 +1,14 @@
+<div id="it-support-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="itModalTitle" style="display: none;">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3 id="itModalTitle" data-en="IT Support" data-es="Soporte IT">IT Support</h3>
+      <button class="close-modal" data-close aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p data-en="Discover our expert IT support services." data-es="Descubra nuestros servicios expertos de IT.">Discover our expert IT support services.</p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="close-modal" data-close data-en="Close" data-es="Cerrar">Close</button>
+    </div>
+  </div>
+</div>

--- a/html/modals/professionals_modal.html
+++ b/html/modals/professionals_modal.html
@@ -1,0 +1,14 @@
+<div id="professionals-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="profModalTitle" style="display: none;">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3 id="profModalTitle" data-en="Professionals" data-es="Profesionales">Professionals</h3>
+      <button class="close-modal" data-close aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p data-en="Meet our network of professionals ready to help." data-es="Conozca nuestra red de profesionales listos para ayudar.">Meet our network of professionals ready to help.</p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="close-modal" data-close data-en="Close" data-es="Cerrar">Close</button>
+    </div>
+  </div>
+</div>

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -219,11 +219,36 @@ document.addEventListener("DOMContentLoaded", () => {
     let lastFocusedElement = null; // To store element that triggered modal
     let loadedModalHTML = {}; // Cache for loaded modal HTML to prevent multiple fetches
 
+    const serviceModalConfig = {
+        'business-operations.html': {
+            id: 'business-operations-modal',
+            file: '/html/modals/business_operations_modal.html',
+            placeholder: 'business-operations-modal-placeholder'
+        },
+        'contact-center.html': {
+            id: 'contact-center-modal',
+            file: '/html/modals/contact_center_modal.html',
+            placeholder: 'contact-center-modal-placeholder'
+        },
+        'it-support.html': {
+            id: 'it-support-modal',
+            file: '/html/modals/it_support_modal.html',
+            placeholder: 'it-support-modal-placeholder'
+        },
+        'professionals.html': {
+            id: 'professionals-modal',
+            file: '/html/modals/professionals_modal.html',
+            placeholder: 'professionals-modal-placeholder'
+        }
+    };
+
     async function loadModalContent(modalId, modalFile, placeholderId, callback) {
-        const placeholder = document.getElementById(placeholderId);
+        let placeholder = document.getElementById(placeholderId);
         if (!placeholder) {
-            console.error(`ERROR:Main/loadModalContent: Placeholder not found: #${placeholderId}`);
-            return null;
+            // Create the placeholder dynamically if it doesn't exist
+            placeholder = document.createElement('div');
+            placeholder.id = placeholderId;
+            document.body.appendChild(placeholder);
         }
 
         if (!loadedModalHTML[modalId]) {
@@ -319,10 +344,32 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
                 setupFocusTrap(targetModal); // Setup focus trap
                 const focusableElement = targetModal.querySelector('input:not([type="hidden"]), button:not([disabled]), [tabindex]:not([tabindex="-1"]), a[href], textarea, select');
-                if (focusableElement) focusableElement.focus();
-                else targetModal.focus(); // Fallback to focusing the modal itself
+            if (focusableElement) focusableElement.focus();
+            else targetModal.focus(); // Fallback to focusing the modal itself
+        }
+    });
+
+    document.addEventListener('click', async (e) => {
+        const anchor = e.target.closest('a[href]');
+        if (!anchor) return;
+        const url = new URL(anchor.getAttribute('href'), document.baseURI);
+        const configKey = Object.keys(serviceModalConfig).find(k => url.pathname.endsWith(k));
+        if (!configKey) return;
+        e.preventDefault();
+        lastFocusedElement = anchor;
+        const cfg = serviceModalConfig[configKey];
+        const modal = await loadModalContent(cfg.id, cfg.file, cfg.placeholder, null);
+        if (modal) {
+            modal.classList.add('active');
+            if (window.updateDynamicContentLanguage) {
+                window.updateDynamicContentLanguage(modal);
             }
-        });
+            setupFocusTrap(modal);
+            const focusable = modal.querySelector('input:not([type="hidden"]), button:not([disabled]), [tabindex]:not([tabindex="-1"]), a[href], textarea, select');
+            if (focusable) focusable.focus();
+            else modal.focus();
+        }
+    });
     });
 
     let currentTrapHandler = null; // To store the current active trap handler


### PR DESCRIPTION
## Summary
- add HTML fragments for each service modal
- style each new modal with dedicated CSS
- enable dynamic loading of service modals on link clicks
- create placeholders on the fly

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685feaba0014832b85fc3b2869ec07c6