### PR TITLE
Fix modal loading paths

### DIFF
--- a/js/pages/chatbot.js
+++ b/js/pages/chatbot.js
@@ -4,7 +4,8 @@
 let chatbotIframe = null;
 let themeObserver = null;
 let iframeLoaded = false;
-const chatbotUrl = '../html/chatbot_creation/chatbot-widget.html';
+const ROOT_PATH = new URL('../..', import.meta.url).pathname;
+const chatbotUrl = `${ROOT_PATH}html/chatbot_creation/chatbot-widget.html`;
 
 // Hidden honeypot field for outer loader (not visible in modal)
 function createLoaderHoneypot() {

--- a/js/pages/contact_us.js
+++ b/js/pages/contact_us.js
@@ -4,6 +4,7 @@
 // `window.CONTACT_WORKER_URL` before loading this script.  Leaving it blank
 // disables form submissions.
 const workerUrl = window.CONTACT_WORKER_URL || "";
+const ROOT_PATH = new URL('../..', import.meta.url).pathname;
 document.addEventListener('DOMContentLoaded', () => {
     const modalPlaceholder = document.getElementById('contact-modal-placeholder');
     // Trigger elements can be identified by a common class or specific IDs
@@ -36,9 +37,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         try {
-            const response = await fetch('../html/modals/contact_us_modal.html');
+            const response = await fetch(`${ROOT_PATH}html/modals/contact_us_modal.html`);
             if (!response.ok) {
-                throw new Error(`Failed to fetch ../html/modals/contact_us_modal.html: ${response.status} ${response.statusText}`);
+                throw new Error(`Failed to fetch ${ROOT_PATH}html/modals/contact_us_modal.html: ${response.status} ${response.statusText}`);
             }
             const htmlText = await response.text();
             const parser = new DOMParser();
@@ -63,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 console.log('Contact modal loaded and initialized.');
             } else {
-                console.error('Could not find #contact-modal.modal-overlay in fetched ../html/modals/contact_us_modal.html');
+                console.error(`Could not find #contact-modal.modal-overlay in fetched ${ROOT_PATH}html/modals/contact_us_modal.html`);
             }
         } catch (error) {
             console.error('Error loading contact modal:', error);

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -7,6 +7,9 @@
 
 import { sanitizeInput } from '../utils/sanitize.js';
 
+// Determine site root based on the location of this script
+const ROOT_PATH = new URL('../..', import.meta.url).pathname;
+
 document.addEventListener("DOMContentLoaded", () => {
     console.log('INFO:Main/DOMContentLoaded: Initializing core functionalities.');
 
@@ -297,14 +300,14 @@ document.addEventListener("DOMContentLoaded", () => {
             } else if (modalId === 'join-us-modal') {
                 targetModal = await loadModalContent(
                     modalId,
-                    '../html/modals/join_us_modal.html',
+                    `${ROOT_PATH}html/modals/join_us_modal.html`,
                     'join-us-modal-placeholder',
                     typeof initializeJoinUsModal === 'function' ? initializeJoinUsModal : null
                 );
             } else if (modalId === 'chatbot-modal') {
                 targetModal = await loadModalContent(
                     modalId,
-                    '../html/modals/chatbot_modal.html',
+                    `${ROOT_PATH}html/modals/chatbot_modal.html`,
                     'chatbot-modal-placeholder',
                     typeof initializeChatbotModal === 'function' ? initializeChatbotModal : null
                 );


### PR DESCRIPTION
## Summary
- compute `ROOT_PATH` from script location
- fetch modal HTML and chatbot widget using the repository root

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686018b3a50c832b8a586890aecf3a42