### PR TITLE
Add logging for modal fetch requests

### DIFF
--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -256,8 +256,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (!loadedModalHTML[modalId]) {
             try {
+                console.log(`INFO:Main/loadModalContent: Fetching ${modalFile}`);
                 const response = await fetch(modalFile);
-                if (!response.ok) throw new Error(`Failed to fetch ${modalFile}: ${response.statusText}`);
+                if (!response.ok) {
+                    console.error(`ERROR:Main/loadModalContent: Fetch failed with status ${response.status} for ${response.url}`);
+                    throw new Error(`Failed to fetch ${modalFile}: ${response.statusText}`);
+                }
                 const html = await response.text();
                 loadedModalHTML[modalId] = html;
                 placeholder.innerHTML = html;


### PR DESCRIPTION
## Summary
- log the URL before fetching modal content in main.js
- report status code and URL when modal fetch fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68602ef95134832bb5322ff654ec279c