### PR TITLE
Add ROOT_PATH module

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,6 @@
   <script type="module" src="js/pages/main.js" defer></script>
   <script type="module" src="js/pages/contact_us.js" defer></script>
   <script src="js/pages/join_us.js" defer></script>
-  <script src="js/pages/chatbot.js" defer></script>
+  <script type="module" src="js/pages/chatbot.js" defer></script>
 </body>
 </html>

--- a/js/pages/chatbot.js
+++ b/js/pages/chatbot.js
@@ -1,10 +1,13 @@
 // js/chatbot.js - Iframe Loader for the new chatbot modal system
 // Loader for chatbot modal: Cloudflare Worker POST & honeypot check
 
+import { ROOT_PATH } from '../utils/rootPath.js';
+
 let chatbotIframe = null;
 let themeObserver = null;
+
 let iframeLoaded = false;
-const chatbotUrl = '../html/chatbot_creation/chatbot-widget.html';
+const chatbotUrl = `${ROOT_PATH}html/chatbot_creation/chatbot-widget.html`;
 const chatbotOrigin = new URL(chatbotUrl, window.location.href).origin;
 
 function postThemeToIframe(theme) {

--- a/js/pages/contact_us.js
+++ b/js/pages/contact_us.js
@@ -3,8 +3,8 @@
 // Cloudflare Worker endpoint.  This can be configured globally by defining
 // `window.CONTACT_WORKER_URL` before loading this script.  Leaving it blank
 // disables form submissions.
+import { ROOT_PATH } from '../utils/rootPath.js';
 const workerUrl = window.CONTACT_WORKER_URL || "";
-const ROOT_PATH = new URL('../..', import.meta.url).pathname;
 document.addEventListener('DOMContentLoaded', () => {
     const modalPlaceholder = document.getElementById('contact-modal-placeholder');
     // Trigger elements can be identified by a common class or specific IDs

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -6,9 +6,7 @@
  *****************************************************/
 
 import { sanitizeInput } from '../utils/sanitize.js';
-
-// Determine site root based on the location of this script
-const ROOT_PATH = new URL('../..', import.meta.url).pathname;
+import { ROOT_PATH } from '../utils/rootPath.js';
 
 document.addEventListener("DOMContentLoaded", () => {
     console.log('INFO:Main/DOMContentLoaded: Initializing core functionalities.');

--- a/js/utils/rootPath.js
+++ b/js/utils/rootPath.js
@@ -1,0 +1,1 @@
+export const ROOT_PATH = new URL('../..', import.meta.url).pathname;


### PR DESCRIPTION
## Summary
- centralize ROOT_PATH constant in `js/utils/rootPath.js`
- reuse ROOT_PATH in main, contact_us and chatbot
- load chatbot script as a module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68602ff43714832b8cbefea4e3138edf