### PR TITLE
Ensure modals cached by service worker

### DIFF
--- a/js/service-worker.js
+++ b/js/service-worker.js
@@ -9,7 +9,9 @@ const urlsToCache = [
   '/offline.html',
   '/css/base/global.css',
   '/css/base/small-screens.css',
-  '/js/pages/main.js'
+  '/js/pages/main.js',
+  '/html/modals/join_us_modal.html',
+  '/html/modals/chatbot_modal.html'
   // Add other important assets that should be cached for offline use
 ];
 


### PR DESCRIPTION
## Summary
- include `join_us_modal.html` and `chatbot_modal.html` in service worker cache

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl -I http://localhost:8000/html/modals/join_us_modal.html`
- `curl -I http://localhost:8000/html/modals/chatbot_modal.html`


------
https://chatgpt.com/codex/tasks/task_e_68603282c844832b9218b7dd067e701a