### PR TITLE
Fix Join Us modal visibility

### DIFF
--- a/html/modals/join_us_modal.html
+++ b/html/modals/join_us_modal.html
@@ -1,4 +1,4 @@
-<div id="join-us-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="joinUsModalTitle" style="display: none;">
+<div id="join-us-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="joinUsModalTitle">
   <div class="modal-content">
     <div class="modal-header">
       <h3 id="joinUsModalTitle" data-en="Join Us" data-es="Únete a Nosotros">Join Us</h3>


### PR DESCRIPTION
## Summary
- remove inline `display:none` from `join_us_modal.html` so `.active` can show it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686041705aa8832b9cd4125746483f02