### PR TITLE
Fix Join Us modal visibility

### DIFF
--- a/css/modals/join_us_modal.css
+++ b/css/modals/join_us_modal.css
@@ -6,16 +6,19 @@
 /* Styles for the form grid inside the modal */
 #join-us-modal .modal-body .form-grid {
   display: grid;
-  grid-template-columns: 1fr; /* Default to single column for modal */
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1rem;
 }
 
-/* On larger screens, allow two columns if desired and content fits well */
 @media (min-width: 768px) {
   #join-us-modal .modal-body .form-grid {
-    grid-template-columns: 1fr 1fr;
     gap: 1.5rem;
   }
+}
+
+/* Widen modal for better viewing */
+#join-us-modal .modal-content {
+  max-width: 800px;
 }
 
 #join-us-modal .form-row,

--- a/html/modals/join_us_modal.html
+++ b/html/modals/join_us_modal.html
@@ -1,4 +1,4 @@
-<div id="join-us-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="joinUsModalTitle" style="display: none;">
+<div id="join-us-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="joinUsModalTitle">
   <div class="modal-content">
     <div class="modal-header">
       <h3 id="joinUsModalTitle" data-en="Join Us" data-es="Únete a Nosotros">Join Us</h3>


### PR DESCRIPTION
## Summary
- remove inline `display:none` from `join_us_modal.html` so `.active` can show it
- adjust Join Us grid distribution
- widen Join Us modal container for better viewing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686041705aa8832b9cd4125746483f02