### PR TITLE
Fix mobile chat button to open chatbot modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
     </button>
     <button class="mobile-nav-item" id="mobile-language-toggle" aria-label="Switch Language" title="Switch Language">EN</button>
     <button class="mobile-nav-item" id="mobile-theme-toggle" aria-label="Toggle Theme" title="Toggle Theme">Light</button>
-    <button class="mobile-nav-item" id="mobileChatLauncher" aria-label="Open Chat" title="Open Chat">
+    <button class="mobile-nav-item" id="mobileChatLauncher" data-modal="chatbot-modal" aria-label="Open Chat" title="Open Chat">
       <i class="fas fa-comment-alt"></i>
       <span>Chat</span>
     </button>

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -314,45 +314,58 @@ document.addEventListener("DOMContentLoaded", () => {
         return targetModalElement;
     }
 
+    async function openModalById(modalId) {
+        if (!modalId) return null;
+        let targetModal;
+        if (modalId === 'contact-modal') {
+            targetModal = document.getElementById(modalId);
+        } else if (modalId === 'join-us-modal') {
+            targetModal = await loadModalContent(
+                modalId,
+                `${ROOT_PATH}html/modals/join_us_modal.html`,
+                'join-us-modal-placeholder',
+                typeof initializeJoinUsModal === 'function' ? initializeJoinUsModal : null
+            );
+        } else if (modalId === 'chatbot-modal') {
+            targetModal = await loadModalContent(
+                modalId,
+                `${ROOT_PATH}html/modals/chatbot_modal.html`,
+                'chatbot-modal-placeholder',
+                typeof initializeChatbotModal === 'function' ? initializeChatbotModal : null
+            );
+        }
+        // Add other dynamic modals here with else if
+
+        if (targetModal) {
+            targetModal.classList.add('active');
+            if (window.updateDynamicContentLanguage) {
+                window.updateDynamicContentLanguage(targetModal);
+            }
+            setupFocusTrap(targetModal);
+            const focusableElement = targetModal.querySelector('input:not([type="hidden"]), button:not([disabled]), [tabindex]:not([tabindex="-1"]), a[href], textarea, select');
+            if (focusableElement) focusableElement.focus();
+            else targetModal.focus();
+        }
+        return targetModal;
+    }
+
     modalTriggers.forEach(trigger => {
         trigger.addEventListener('click', async (event) => {
             lastFocusedElement = event.currentTarget;
             const modalId = event.currentTarget.dataset.modal;
-            if (!modalId) return;
-
-            let targetModal;
-
-            if (modalId === 'contact-modal') { // Existing static modal
-                targetModal = document.getElementById(modalId);
-            } else if (modalId === 'join-us-modal') {
-                targetModal = await loadModalContent(
-                    modalId,
-                    `${ROOT_PATH}html/modals/join_us_modal.html`,
-                    'join-us-modal-placeholder',
-                    typeof initializeJoinUsModal === 'function' ? initializeJoinUsModal : null
-                );
-            } else if (modalId === 'chatbot-modal') {
-                targetModal = await loadModalContent(
-                    modalId,
-                    `${ROOT_PATH}html/modals/chatbot_modal.html`,
-                    'chatbot-modal-placeholder',
-                    typeof initializeChatbotModal === 'function' ? initializeChatbotModal : null
-                );
-            }
-            // Add other dynamic modals here with else if (modalId === 'another-modal') { ... }
-
-            if (targetModal) {
-                targetModal.classList.add('active');
-                // Update language for the newly loaded/shown modal
-                if (window.updateDynamicContentLanguage) {
-                    window.updateDynamicContentLanguage(targetModal);
-                }
-                setupFocusTrap(targetModal); // Setup focus trap
-                const focusableElement = targetModal.querySelector('input:not([type="hidden"]), button:not([disabled]), [tabindex]:not([tabindex="-1"]), a[href], textarea, select');
-            if (focusableElement) focusableElement.focus();
-            else targetModal.focus(); // Fallback to focusing the modal itself
-        }
+            await openModalById(modalId);
+        });
     });
+
+    const mobileChatLauncherBtn = document.getElementById('mobileChatLauncher');
+    if (mobileChatLauncherBtn) {
+        mobileChatLauncherBtn.addEventListener('click', async (event) => {
+            lastFocusedElement = event.currentTarget;
+            await openModalById('chatbot-modal');
+        });
+    }
+
+    window.openModalById = openModalById;
 
     document.addEventListener('click', async (e) => {
         const anchor = e.target.closest('a[href]');


### PR DESCRIPTION
## Summary
- add helper to open modals by id
- wire mobile chat button to load chatbot modal using new helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68604d60bdb0832bbf1c7082bd151358