### PR TITLE
Fix chatbot modal visibility

### DIFF
--- a/html/modals/chatbot_modal.html
+++ b/html/modals/chatbot_modal.html
@@ -1,4 +1,4 @@
-<div id="chatbot-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="chatbotModalTitle" style="display: none;">
+<div id="chatbot-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="chatbotModalTitle">
   <div class="modal-content">
     <div class="modal-header">
       <h3 id="chatbotModalTitle" data-en="AI Chatbot" data-es="Chatbot IA">AI Chatbot</h3>


### PR DESCRIPTION
## Summary
- remove inline display:none from chatbot modal to allow it to open

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860ae2b9fd4832b9c34793c0cd39885