### PR TITLE
Fix service worker path and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" crossorigin="anonymous">
   <!-- Manifest and Favicon -->
   <link rel="manifest" href="manifest.json">
-  <link rel="icon" href="assets/favicon.ico">
+  <link rel="icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAGAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA////AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA">
 </head>
 
 <body>

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -507,7 +507,7 @@ document.addEventListener("DOMContentLoaded", () => {
        ================================================================= */
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-            navigator.serviceWorker.register('js/service-worker.js')
+            navigator.serviceWorker.register(`${ROOT_PATH}js/service-worker.js`)
                 .then(reg => console.log('INFO:Main/ServiceWorker: Registered. Scope:', reg.scope))
                 .catch(err => console.error('ERROR:Main/ServiceWorker: Registration failed:', err));
         });


### PR DESCRIPTION
## Summary
- fix service worker registration to use correct root path
- embed favicon as base64 data URI to avoid missing asset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68617eadd2e0832b8804c28222b61250