### PR TITLE
Fix language toggle ID mismatch

### DIFF
--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -28,7 +28,8 @@ document.addEventListener("DOMContentLoaded", () => {
     let currentLanguage = localStorage.getItem("language") || "en";
 
     const langToggleDesktop = document.getElementById("language-toggle-desktop");
-    const langToggleMobile  = document.getElementById("language-toggle-mobile");
+    // Correct ID for the mobile language toggle
+    const langToggleMobile  = document.getElementById("mobile-language-toggle");
 
     function updateNodeLanguageTexts(lang, parentNode = document.body) {
         if (!parentNode) {


### PR DESCRIPTION
## Summary
- fix the mobile language toggle by using the correct element ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861b48873ec832bb80d31f110b6569f