### PR TITLE
Fix chatbot container border color

### DIFF
--- a/css/chatbot_creation/chatbot-container.css
+++ b/css/chatbot_creation/chatbot-container.css
@@ -23,7 +23,8 @@ body[data-theme="dark"] {
     flex-grow: 1;
     overflow: hidden;
     margin: 2px;
-    border: 2px solid royalpurple;
+    /* Use a valid CSS color for the border */
+    border: 2px solid rebeccapurple;
 }
 
 body[data-theme="dark"] #chatbot-container {


### PR DESCRIPTION
## Summary
- fix invalid CSS color in chatbot container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861b5f845b4832b8a91a6b5f66e6c19