### PR TITLE
Fix join-us modal accessibility and behavior

### DIFF
--- a/html/modals/join_us_modal.html
+++ b/html/modals/join_us_modal.html
@@ -1,4 +1,4 @@
-<div id="join-us-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="joinUsModalTitle">
+<div id="join-us-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="joinUsModalTitle" aria-hidden="true">
   <div class="modal-content">
     <div class="modal-header">
       <h3 id="joinUsModalTitle" data-en="Join Us" data-es="Únete">Join Us</h3>

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -338,6 +338,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (targetModal) {
             targetModal.classList.add('active');
+            targetModal.setAttribute('aria-hidden', 'false');
             if (window.updateDynamicContentLanguage) {
                 window.updateDynamicContentLanguage(targetModal);
             }
@@ -447,6 +448,7 @@ document.addEventListener("DOMContentLoaded", () => {
     function closeModal(modalElement) {
         if (modalElement) {
             modalElement.classList.remove('active');
+            modalElement.setAttribute('aria-hidden', 'true');
             removeFocusTrap();
             if (lastFocusedElement) lastFocusedElement.focus();
         }


### PR DESCRIPTION
## Summary
- add `aria-hidden` flag to Join Us modal HTML
- toggle `aria-hidden` attribute when modals open and close for accessibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861fd027ee8832bae0424ae774b15a0