### PR TITLE
Fix: Correct syntax error preventing Join Us modal from appearing

### DIFF
--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -399,7 +399,6 @@ document.addEventListener("DOMContentLoaded", () => {
         'join-us-modal-placeholder',
         initializeJoinUsModal
     ).catch(err => console.error('ERROR:Main/JoinUsPreload:', err));
-    });
 
     let currentTrapHandler = null; // To store the current active trap handler
 


### PR DESCRIPTION
Removed an extraneous `});` in `js/pages/main.js` that caused a JavaScript parsing error. This error prevented the event listeners and modal loading logic from executing correctly, thus the Join Us modal would not appear on click.

With this syntax error fixed, the modal should now load and display as intended.