### PR TITLE
Fix: Ensure Contact Us modal opens from footer button

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
        ================================================================== -->
   <footer>
     <p>&copy; 2025 Ops Online Support. All rights reserved.</p>
-    <button id="footer-contact-us-button" class="btn" data-en="Contact Us" data-es="Contáctenos">Contact Us</button>
+    <button id="footer-contact-us-button" class="btn" data-modal="contact-modal" data-en="Contact Us" data-es="Contáctenos">Contact Us</button>
   </footer>
 
   <!-- ==================================================================


### PR DESCRIPTION
The footer 'Contact Us' button was missing the 'data-modal' attribute, preventing it from triggering the modal opening logic in main.js.

This commit adds the 'data-modal="contact-modal"' attribute to the button, enabling it to correctly open the Contact Us modal on click. The floating icon button for the same modal was already functional.