### PR TITLE
Refactor: Ensure website adaptability for small screens

### DIFF
--- a/css/base/small-screens.css
+++ b/css/base/small-screens.css
@@ -41,6 +41,11 @@ on-guard/css/small-screens.css
 
     /* Form layout stacking (if .form-row/.form-cell is used within general modals) */
     /* User's global.css @media uses grid-template-columns: 1fr for .modal-body form */
+    /* Adding the general rule for modal forms to stack on small screens */
+    .modal-body form {
+        grid-template-columns: 1fr; /* Stack grid items into a single column */
+        gap: 0.75rem; /* Adjust gap for single column layout */
+    }
     /* This .form-row/.form-cell is a flex alternative. If grid is global, this can be removed. */
     /* .form-row {
         flex-direction: column;


### PR DESCRIPTION
- Verified that the main desktop navigation menu is hidden on small devices (<= 768px) via existing CSS.
- Ensured mobile navigation (rightSideMenu) is available and functional.
- Added a general CSS rule to `small-screens.css` to make forms within service modals stack vertically (single column) on small devices (<= 768px). This addresses the requirement for vertical alignment of modal content, particularly forms.
- This change provides a consistent default for modal form responsiveness, while specific modal CSS (e.g., for Contact Us modal) can still override it.