### PR TITLE
Enable bilingual metadata and alerts

### DIFF
--- a/html/about.html
+++ b/html/about.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>About Us</title>
+    <title data-en="About Us" data-es="Sobre Nosotros">About Us</title>
     <link rel="stylesheet" href="../css/base/global.css">
-    <meta name="description" content="Learn more about Ops Online Support.">
+    <meta name="description" content="Learn more about Ops Online Support." data-en-content="Learn more about Ops Online Support." data-es-content="Aprende más sobre Ops Online Support.">
 </head>
 <body>
     <header>
@@ -20,10 +20,19 @@
       </nav>
       <div class="header-controls">
         <div class="toggle-container">
-          <button id="theme-toggle-desktop" title="Toggle Theme">Light</button>
-          <button id="language-toggle-desktop" title="Switch Language">EN</button>
+        <button id="theme-toggle-desktop" title="Toggle Theme"
+                data-en-label-dark="Switch to Dark Theme"
+                data-es-label-dark="Cambiar a Tema Oscuro"
+                data-en-label-light="Switch to Light Theme"
+                data-es-label-light="Cambiar a Tema Claro"
+                data-en-dark="Dark" data-es-dark="Oscuro"
+                data-en-light="Light" data-es-light="Claro">Light</button>
+          <button id="language-toggle-desktop" title="Switch Language"
+                data-en-label="Switch to Spanish" data-es-label="Cambiar a Inglés">EN</button>
         </div>
-        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu">
+        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu"
+                data-en-label="Open Main Menu" data-es-label="Abrir Menú Principal"
+                data-en-title="Open Menu" data-es-title="Abrir Menú">
           <i class="fas fa-bars"></i>
         </button>
       </div>
@@ -32,7 +41,9 @@
     <aside id="rightSideMenu" class="right-side-menu" role="navigation" aria-labelledby="rightSideMenuTitle">
       <div class="right-side-menu-header">
         <h2 id="rightSideMenuTitle" class="sr-only">Main Menu</h2>
-        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu">
+        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu"
+                data-en-label="Close Main Menu" data-es-label="Cerrar Menú Principal"
+                data-en-title="Close Menu" data-es-title="Cerrar Menú">
           <i class="fas fa-times"></i>
         </button>
       </div>
@@ -60,9 +71,9 @@
       </div>
     </aside>
     <main>
-        <h1>About Us</h1>
-        <p>Information about our company will be added here.</p>
-        <p><a href="../index.html">Back to Home</a></p>
+        <h1 data-en="About Us" data-es="Sobre Nosotros">About Us</h1>
+        <p data-en="Information about our company will be added here." data-es="Se agregará información sobre nuestra empresa aquí.">Information about our company will be added here.</p>
+        <p><a href="../index.html" data-en="Back to Home" data-es="Volver a Inicio">Back to Home</a></p>
     </main>
     <footer>
         <p>&copy; 2025 Ops Online Support. All rights reserved.</p>

--- a/html/blog.html
+++ b/html/blog.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Blog</title>
+    <title data-en="Blog" data-es="Blog">Blog</title>
     <link rel="stylesheet" href="../css/base/global.css">
-    <meta name="description" content="Read the latest news and articles from Ops Online Support.">
+    <meta name="description" content="Read the latest news and articles from Ops Online Support." data-en-content="Read the latest news and articles from Ops Online Support." data-es-content="Lee las últimas noticias y artículos de Ops Online Support.">
 </head>
 <body>
     <header>
@@ -20,10 +20,19 @@
       </nav>
       <div class="header-controls">
         <div class="toggle-container">
-          <button id="theme-toggle-desktop" title="Toggle Theme">Light</button>
-          <button id="language-toggle-desktop" title="Switch Language">EN</button>
+        <button id="theme-toggle-desktop" title="Toggle Theme"
+                data-en-label-dark="Switch to Dark Theme"
+                data-es-label-dark="Cambiar a Tema Oscuro"
+                data-en-label-light="Switch to Light Theme"
+                data-es-label-light="Cambiar a Tema Claro"
+                data-en-dark="Dark" data-es-dark="Oscuro"
+                data-en-light="Light" data-es-light="Claro">Light</button>
+          <button id="language-toggle-desktop" title="Switch Language"
+                data-en-label="Switch to Spanish" data-es-label="Cambiar a Inglés">EN</button>
         </div>
-        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu">
+        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu"
+                data-en-label="Open Main Menu" data-es-label="Abrir Menú Principal"
+                data-en-title="Open Menu" data-es-title="Abrir Menú">
           <i class="fas fa-bars"></i>
         </button>
       </div>
@@ -32,7 +41,9 @@
     <aside id="rightSideMenu" class="right-side-menu" role="navigation" aria-labelledby="rightSideMenuTitle">
       <div class="right-side-menu-header">
         <h2 id="rightSideMenuTitle" class="sr-only">Main Menu</h2>
-        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu">
+        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu"
+                data-en-label="Close Main Menu" data-es-label="Cerrar Menú Principal"
+                data-en-title="Close Menu" data-es-title="Cerrar Menú">
           <i class="fas fa-times"></i>
         </button>
       </div>
@@ -60,9 +71,9 @@
       </div>
     </aside>
     <main>
-        <h1>Blog</h1>
-        <p>Our blog posts and articles will be added here.</p>
-        <p><a href="../index.html">Back to Home</a></p>
+        <h1 data-en="Blog" data-es="Blog">Blog</h1>
+        <p data-en="Our blog posts and articles will be added here." data-es="Nuestros artículos y publicaciones se agregarán aquí.">Our blog posts and articles will be added here.</p>
+        <p><a href="../index.html" data-en="Back to Home" data-es="Volver a Inicio">Back to Home</a></p>
     </main>
     <footer>
         <p>&copy; 2025 Ops Online Support. All rights reserved.</p>

--- a/html/business-operations.html
+++ b/html/business-operations.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Business Operations</title>
+    <title data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</title>
     <link rel="stylesheet" href="../css/base/global.css">
-    <meta name="description" content="Details about our Business Operations services.">
+    <meta name="description" content="Details about our Business Operations services." data-en-content="Details about our Business Operations services." data-es-content="Detalles sobre nuestros servicios de Operaciones Empresariales.">
 </head>
 <body>
     <header>
@@ -20,10 +20,19 @@
       </nav>
       <div class="header-controls">
         <div class="toggle-container">
-          <button id="theme-toggle-desktop" title="Toggle Theme">Light</button>
-          <button id="language-toggle-desktop" title="Switch Language">EN</button>
+        <button id="theme-toggle-desktop" title="Toggle Theme"
+                data-en-label-dark="Switch to Dark Theme"
+                data-es-label-dark="Cambiar a Tema Oscuro"
+                data-en-label-light="Switch to Light Theme"
+                data-es-label-light="Cambiar a Tema Claro"
+                data-en-dark="Dark" data-es-dark="Oscuro"
+                data-en-light="Light" data-es-light="Claro">Light</button>
+          <button id="language-toggle-desktop" title="Switch Language"
+                data-en-label="Switch to Spanish" data-es-label="Cambiar a Inglés">EN</button>
         </div>
-        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu">
+        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu"
+                data-en-label="Open Main Menu" data-es-label="Abrir Menú Principal"
+                data-en-title="Open Menu" data-es-title="Abrir Menú">
           <i class="fas fa-bars"></i>
         </button>
       </div>
@@ -32,7 +41,9 @@
     <aside id="rightSideMenu" class="right-side-menu" role="navigation" aria-labelledby="rightSideMenuTitle">
       <div class="right-side-menu-header">
         <h2 id="rightSideMenuTitle" class="sr-only">Main Menu</h2>
-        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu">
+        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu"
+                data-en-label="Close Main Menu" data-es-label="Cerrar Menú Principal"
+                data-en-title="Close Menu" data-es-title="Cerrar Menú">
           <i class="fas fa-times"></i>
         </button>
       </div>
@@ -60,9 +71,9 @@
       </div>
     </aside>
     <main>
-        <h1>Business Operations</h1>
-        <p>Content for Business Operations will be added here.</p>
-        <p><a href="../index.html">Back to Home</a></p>
+        <h1 data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</h1>
+        <p data-en="Content for Business Operations will be added here." data-es="El contenido de Operaciones Empresariales se agregará aquí.">Content for Business Operations will be added here.</p>
+        <p><a href="../index.html" data-en="Back to Home" data-es="Volver a Inicio">Back to Home</a></p>
     </main>
     <footer>
         <p>&copy; 2025 Ops Online Support. All rights reserved.</p>

--- a/html/careers.html
+++ b/html/careers.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Careers</title>
+    <title data-en="Careers" data-es="Carreras">Careers</title>
     <link rel="stylesheet" href="../css/base/global.css">
-    <meta name="description" content="Explore career opportunities at Ops Online Support.">
+    <meta name="description" content="Explore career opportunities at Ops Online Support." data-en-content="Explore career opportunities at Ops Online Support." data-es-content="Explora oportunidades de carrera en Ops Online Support.">
 </head>
 <body>
     <header>
@@ -20,10 +20,19 @@
       </nav>
       <div class="header-controls">
         <div class="toggle-container">
-          <button id="theme-toggle-desktop" title="Toggle Theme">Light</button>
-          <button id="language-toggle-desktop" title="Switch Language">EN</button>
+        <button id="theme-toggle-desktop" title="Toggle Theme"
+                data-en-label-dark="Switch to Dark Theme"
+                data-es-label-dark="Cambiar a Tema Oscuro"
+                data-en-label-light="Switch to Light Theme"
+                data-es-label-light="Cambiar a Tema Claro"
+                data-en-dark="Dark" data-es-dark="Oscuro"
+                data-en-light="Light" data-es-light="Claro">Light</button>
+          <button id="language-toggle-desktop" title="Switch Language"
+                data-en-label="Switch to Spanish" data-es-label="Cambiar a Inglés">EN</button>
         </div>
-        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu">
+        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu"
+                data-en-label="Open Main Menu" data-es-label="Abrir Menú Principal"
+                data-en-title="Open Menu" data-es-title="Abrir Menú">
           <i class="fas fa-bars"></i>
         </button>
       </div>
@@ -32,7 +41,9 @@
     <aside id="rightSideMenu" class="right-side-menu" role="navigation" aria-labelledby="rightSideMenuTitle">
       <div class="right-side-menu-header">
         <h2 id="rightSideMenuTitle" class="sr-only">Main Menu</h2>
-        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu">
+        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu"
+                data-en-label="Close Main Menu" data-es-label="Cerrar Menú Principal"
+                data-en-title="Close Menu" data-es-title="Cerrar Menú">
           <i class="fas fa-times"></i>
         </button>
       </div>
@@ -60,9 +71,9 @@
       </div>
     </aside>
     <main>
-        <h1>Careers</h1>
-        <p>Information about job openings and careers at our company will be added here.</p>
-        <p><a href="../index.html">Back to Home</a></p>
+        <h1 data-en="Careers" data-es="Carreras">Careers</h1>
+        <p data-en="Information about job openings and careers at our company will be added here." data-es="Próximamente agregaremos información sobre oportunidades laborales y carreras en nuestra empresa.">Information about job openings and careers at our company will be added here.</p>
+        <p><a href="../index.html" data-en="Back to Home" data-es="Volver a Inicio">Back to Home</a></p>
     </main>
     <footer>
         <p>&copy; 2025 Ops Online Support. All rights reserved.</p>

--- a/html/chatbot_creation/chatbot-widget.html
+++ b/html/chatbot_creation/chatbot-widget.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>OPS Chatbot</title>
+  <title data-en="OPS Chatbot" data-es="OPS Chatbot">OPS Chatbot</title>
   <!-- Styles for the iframe content -->
   <link rel="stylesheet" href="../../css/chatbot_creation/chatbot-container.css">
   <link rel="stylesheet" href="../../css/chatbot_creation/chatbot-ui.css">
@@ -14,7 +14,18 @@
   <div id="chatbot-container">
     <div id="chat-log" class="chat-log"></div>
     <form id="chat-form" class="chat-form" autocomplete="off">
-      <input type="text" id="chat-input" placeholder="Verify you are human, then ask me anything" autocomplete="off" required aria-label="Verify you are human, then ask me anything" />
+      <input
+        type="text"
+        id="chat-input"
+        placeholder="Verify you are human, then ask me anything"
+        autocomplete="off"
+        required
+        aria-label="Verify you are human, then ask me anything"
+        data-en-placeholder="Verify you are human, then ask me anything"
+        data-es-placeholder="Verifica que eres humano y luego preguntame lo que sea"
+        data-en-label="Verify you are human, then ask me anything"
+        data-es-label="Verifica que eres humano y luego preguntame lo que sea"
+      />
 
       <!-- Human verification -->
       <div class="recaptcha-placeholder-container" id="recaptcha-inline-placeholder">
@@ -27,7 +38,15 @@
       <!-- Honeypot Field: fully hidden and always present -->
       <input type="text" name="chatbot-honeypot" class="ops-chatbot-honeypot-field"
         tabindex="-1" autocomplete="off" aria-hidden="true" style="display:none;">
-      <button type="submit" id="chat-send-button" aria-label="Send Message" data-en-label="Send Message" data-es-label="Enviar Mensaje">Send</button>
+      <button
+        type="submit"
+        id="chat-send-button"
+        aria-label="Send Message"
+        data-en="Send"
+        data-es="Enviar"
+        data-en-label="Send Message"
+        data-es-label="Enviar Mensaje"
+      >Send</button>
     </form>
     <!-- HIGHLIGHT: reCAPTCHA is fully integrated and enabled via the widget JS -->
   </div>

--- a/html/contact-center.html
+++ b/html/contact-center.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact Center</title>
+    <title data-en="Contact Center" data-es="Centro de Contacto">Contact Center</title>
     <link rel="stylesheet" href="../css/base/global.css">
-    <meta name="description" content="Details about our Contact Center solutions.">
+    <meta name="description" content="Details about our Contact Center solutions." data-en-content="Details about our Contact Center solutions." data-es-content="Detalles sobre nuestras soluciones de Centro de Contacto.">
 </head>
 <body>
     <header>
@@ -20,10 +20,19 @@
       </nav>
       <div class="header-controls">
         <div class="toggle-container">
-          <button id="theme-toggle-desktop" title="Toggle Theme">Light</button>
-          <button id="language-toggle-desktop" title="Switch Language">EN</button>
+        <button id="theme-toggle-desktop" title="Toggle Theme"
+                data-en-label-dark="Switch to Dark Theme"
+                data-es-label-dark="Cambiar a Tema Oscuro"
+                data-en-label-light="Switch to Light Theme"
+                data-es-label-light="Cambiar a Tema Claro"
+                data-en-dark="Dark" data-es-dark="Oscuro"
+                data-en-light="Light" data-es-light="Claro">Light</button>
+          <button id="language-toggle-desktop" title="Switch Language"
+                data-en-label="Switch to Spanish" data-es-label="Cambiar a Inglés">EN</button>
         </div>
-        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu">
+        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu"
+                data-en-label="Open Main Menu" data-es-label="Abrir Menú Principal"
+                data-en-title="Open Menu" data-es-title="Abrir Menú">
           <i class="fas fa-bars"></i>
         </button>
       </div>
@@ -32,7 +41,9 @@
     <aside id="rightSideMenu" class="right-side-menu" role="navigation" aria-labelledby="rightSideMenuTitle">
       <div class="right-side-menu-header">
         <h2 id="rightSideMenuTitle" class="sr-only">Main Menu</h2>
-        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu">
+        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu"
+                data-en-label="Close Main Menu" data-es-label="Cerrar Menú Principal"
+                data-en-title="Close Menu" data-es-title="Cerrar Menú">
           <i class="fas fa-times"></i>
         </button>
       </div>
@@ -60,9 +71,9 @@
       </div>
     </aside>
     <main>
-        <h1>Contact Center</h1>
-        <p>Content for Contact Center solutions will be added here.</p>
-        <p><a href="../index.html">Back to Home</a></p>
+        <h1 data-en="Contact Center" data-es="Centro de Contacto">Contact Center</h1>
+        <p data-en="Content for Contact Center solutions will be added here." data-es="El contenido para las soluciones de Centro de Contacto se agregará aquí.">Content for Contact Center solutions will be added here.</p>
+        <p><a href="../index.html" data-en="Back to Home" data-es="Volver a Inicio">Back to Home</a></p>
     </main>
     <footer>
         <p>&copy; 2025 Ops Online Support. All rights reserved.</p>

--- a/html/it-support.html
+++ b/html/it-support.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>IT Support</title>
+    <title data-en="IT Support" data-es="Soporte IT">IT Support</title>
     <link rel="stylesheet" href="../css/base/global.css">
-    <meta name="description" content="Details about our IT Support services.">
+    <meta name="description" content="Details about our IT Support services." data-en-content="Details about our IT Support services." data-es-content="Detalles sobre nuestros servicios de Soporte IT.">
 </head>
 <body>
     <header>
@@ -20,10 +20,19 @@
       </nav>
       <div class="header-controls">
         <div class="toggle-container">
-          <button id="theme-toggle-desktop" title="Toggle Theme">Light</button>
-          <button id="language-toggle-desktop" title="Switch Language">EN</button>
+        <button id="theme-toggle-desktop" title="Toggle Theme"
+                data-en-label-dark="Switch to Dark Theme"
+                data-es-label-dark="Cambiar a Tema Oscuro"
+                data-en-label-light="Switch to Light Theme"
+                data-es-label-light="Cambiar a Tema Claro"
+                data-en-dark="Dark" data-es-dark="Oscuro"
+                data-en-light="Light" data-es-light="Claro">Light</button>
+          <button id="language-toggle-desktop" title="Switch Language"
+                data-en-label="Switch to Spanish" data-es-label="Cambiar a Inglés">EN</button>
         </div>
-        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu">
+        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu"
+                data-en-label="Open Main Menu" data-es-label="Abrir Menú Principal"
+                data-en-title="Open Menu" data-es-title="Abrir Menú">
           <i class="fas fa-bars"></i>
         </button>
       </div>
@@ -32,7 +41,9 @@
     <aside id="rightSideMenu" class="right-side-menu" role="navigation" aria-labelledby="rightSideMenuTitle">
       <div class="right-side-menu-header">
         <h2 id="rightSideMenuTitle" class="sr-only">Main Menu</h2>
-        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu">
+        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu"
+                data-en-label="Close Main Menu" data-es-label="Cerrar Menú Principal"
+                data-en-title="Close Menu" data-es-title="Cerrar Menú">
           <i class="fas fa-times"></i>
         </button>
       </div>
@@ -60,9 +71,9 @@
       </div>
     </aside>
     <main>
-        <h1>IT Support</h1>
-        <p>Content for IT Support services will be added here.</p>
-        <p><a href="../index.html">Back to Home</a></p>
+        <h1 data-en="IT Support" data-es="Soporte IT">IT Support</h1>
+        <p data-en="Content for IT Support services will be added here." data-es="El contenido para los servicios de Soporte IT se agregará aquí.">Content for IT Support services will be added here.</p>
+        <p><a href="../index.html" data-en="Back to Home" data-es="Volver a Inicio">Back to Home</a></p>
     </main>
     <footer>
         <p>&copy; 2025 Ops Online Support. All rights reserved.</p>

--- a/html/partials/header.html
+++ b/html/partials/header.html
@@ -9,20 +9,28 @@
     </ul>
   </nav>
   <div class="header-controls">
-    <div class="toggle-container">
-      <button id="theme-toggle-desktop" title="Toggle Theme">Light</button>
-      <button id="language-toggle-desktop" title="Switch Language">EN</button>
-    </div>
-    <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu">
-      <i class="fas fa-bars"></i>
-    </button>
+  <div class="toggle-container">
+    <button id="theme-toggle-desktop" title="Toggle Theme"
+            data-en-label-dark="Switch to Dark Theme" data-es-label-dark="Cambiar a Tema Oscuro"
+            data-en-label-light="Switch to Light Theme" data-es-label-light="Cambiar a Tema Claro"
+            data-en-dark="Dark" data-es-dark="Oscuro" data-en-light="Light" data-es-light="Claro">Light</button>
+    <button id="language-toggle-desktop" title="Switch Language"
+            data-en-label="Switch to Spanish" data-es-label="Cambiar a Inglés">EN</button>
+  </div>
+  <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu"
+          data-en-label="Open Main Menu" data-es-label="Abrir Menú Principal"
+          data-en-title="Open Menu" data-es-title="Abrir Menú">
+    <i class="fas fa-bars"></i>
+  </button>
   </div>
 </header>
 
 <aside id="rightSideMenu" class="right-side-menu" role="navigation" aria-labelledby="rightSideMenuTitle">
   <div class="right-side-menu-header">
     <h2 id="rightSideMenuTitle" class="sr-only">Main Menu</h2>
-    <button id="menu-close" aria-label="Close Main Menu" title="Close Menu">
+    <button id="menu-close" aria-label="Close Main Menu" title="Close Menu"
+            data-en-label="Close Main Menu" data-es-label="Cerrar Menú Principal"
+            data-en-title="Close Menu" data-es-title="Cerrar Menú">
       <i class="fas fa-times"></i>
     </button>
   </div>

--- a/html/professionals.html
+++ b/html/professionals.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Professionals</title>
+    <title data-en="Professionals" data-es="Profesionales">Professionals</title>
     <link rel="stylesheet" href="../css/base/global.css">
-    <meta name="description" content="Information about our Professionals services.">
+    <meta name="description" content="Information about our Professionals services." data-en-content="Information about our Professionals services." data-es-content="Información sobre nuestros servicios de Profesionales.">
 </head>
 <body>
     <header>
@@ -20,10 +20,19 @@
       </nav>
       <div class="header-controls">
         <div class="toggle-container">
-          <button id="theme-toggle-desktop" title="Toggle Theme">Light</button>
-          <button id="language-toggle-desktop" title="Switch Language">EN</button>
+        <button id="theme-toggle-desktop" title="Toggle Theme"
+                data-en-label-dark="Switch to Dark Theme"
+                data-es-label-dark="Cambiar a Tema Oscuro"
+                data-en-label-light="Switch to Light Theme"
+                data-es-label-light="Cambiar a Tema Claro"
+                data-en-dark="Dark" data-es-dark="Oscuro"
+                data-en-light="Light" data-es-light="Claro">Light</button>
+          <button id="language-toggle-desktop" title="Switch Language"
+                data-en-label="Switch to Spanish" data-es-label="Cambiar a Inglés">EN</button>
         </div>
-        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu">
+        <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu"
+                data-en-label="Open Main Menu" data-es-label="Abrir Menú Principal"
+                data-en-title="Open Menu" data-es-title="Abrir Menú">
           <i class="fas fa-bars"></i>
         </button>
       </div>
@@ -32,7 +41,9 @@
     <aside id="rightSideMenu" class="right-side-menu" role="navigation" aria-labelledby="rightSideMenuTitle">
       <div class="right-side-menu-header">
         <h2 id="rightSideMenuTitle" class="sr-only">Main Menu</h2>
-        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu">
+        <button id="menu-close" aria-label="Close Main Menu" title="Close Menu"
+                data-en-label="Close Main Menu" data-es-label="Cerrar Menú Principal"
+                data-en-title="Close Menu" data-es-title="Cerrar Menú">
           <i class="fas fa-times"></i>
         </button>
       </div>
@@ -60,9 +71,9 @@
       </div>
     </aside>
     <main>
-        <h1>Professionals</h1>
-        <p>Content for Professionals services will be added here.</p>
-        <p><a href="../index.html">Back to Home</a></p>
+        <h1 data-en="Professionals" data-es="Profesionales">Professionals</h1>
+        <p data-en="Content for Professionals services will be added here." data-es="El contenido para los servicios Profesionales se agregará aquí.">Content for Professionals services will be added here.</p>
+        <p><a href="../index.html" data-en="Back to Home" data-es="Volver a Inicio">Back to Home</a></p>
     </main>
     <footer>
         <p>&copy; 2025 Ops Online Support. All rights reserved.</p>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
        ================================================================== -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Ops Online Support offers cutting-edge remote business operations, contact center solutions, IT support, and professional staffing.">
-  <title>Ops Online Support</title>
+  <meta name="description" content="Ops Online Support offers cutting-edge remote business operations, contact center solutions, IT support, and professional staffing." data-en-content="Ops Online Support offers cutting-edge remote business operations, contact center solutions, IT support, and professional staffing." data-es-content="Ops Online Support ofrece operaciones empresariales remotas de vanguardia, soluciones de centro de contacto, soporte IT y personal profesional.">
+  <title data-en="Ops Online Support" data-es="Ops Online Soporte">Ops Online Support</title>
   <!-- Base CSS -->
   <link rel="stylesheet" href="css/base/global.css">
   <!-- Responsive Overrides -->
@@ -41,10 +41,24 @@
     </nav>
     <div class="header-controls">
       <div class="toggle-container">
-        <button id="theme-toggle-desktop" title="Toggle Theme">Light</button>
-        <button id="language-toggle-desktop" title="Switch Language">EN</button>
+        <button id="theme-toggle-desktop"
+                title="Toggle Theme"
+                data-en-label-dark="Switch to Dark Theme"
+                data-es-label-dark="Cambiar a Tema Oscuro"
+                data-en-label-light="Switch to Light Theme"
+                data-es-label-light="Cambiar a Tema Claro"
+                data-en-dark="Dark"
+                data-es-dark="Oscuro"
+                data-en-light="Light"
+                data-es-light="Claro">Light</button>
+        <button id="language-toggle-desktop" title="Switch Language"
+                data-en-label="Switch to Spanish"
+                data-es-label="Cambiar a Inglés">EN</button>
       </div>
-      <button id="menu-open" class="header-menu-trigger" aria-label="Open Main Menu" title="Open Menu">
+      <button id="menu-open" class="header-menu-trigger"
+              aria-label="Open Main Menu" title="Open Menu"
+              data-en-label="Open Main Menu" data-es-label="Abrir Menú Principal"
+              data-en-title="Open Menu" data-es-title="Abrir Menú">
         <i class="fas fa-bars"></i>
       </button>
     </div>
@@ -56,7 +70,9 @@
   <aside id="rightSideMenu" class="right-side-menu" role="navigation" aria-labelledby="rightSideMenuTitle">
     <div class="right-side-menu-header">
       <h2 id="rightSideMenuTitle" class="sr-only">Main Menu</h2>
-      <button id="menu-close" aria-label="Close Main Menu" title="Close Menu">
+      <button id="menu-close" aria-label="Close Main Menu" title="Close Menu"
+              data-en-label="Close Main Menu" data-es-label="Cerrar Menú Principal"
+              data-en-title="Close Menu" data-es-title="Cerrar Menú">
         <i class="fas fa-times"></i>
       </button>
     </div>
@@ -130,13 +146,19 @@
        Floating Icons
        ================================================================== -->
   <div class="floating-icons">
-    <button class="floating-icon" data-modal="join-us-modal" aria-label="Join Us" title="Join Us" tabindex="0">
+    <button class="floating-icon" data-modal="join-us-modal" aria-label="Join Us" title="Join Us" tabindex="0"
+            data-en-label="Join Us" data-es-label="Únete"
+            data-en-title="Join Us" data-es-title="Únete">
       <i class="fas fa-user-plus"></i>
     </button>
-    <button class="floating-icon" data-modal="contact-modal" aria-label="Contact Us" title="Contact Us" tabindex="0">
+    <button class="floating-icon" data-modal="contact-modal" aria-label="Contact Us" title="Contact Us" tabindex="0"
+            data-en-label="Contact Us" data-es-label="Contáctanos"
+            data-en-title="Contact Us" data-es-title="Contáctanos">
       <i class="fas fa-envelope-open-text"></i>
     </button>
-    <button class="floating-icon" id="chatbot-fab-trigger" data-modal="chatbot-modal" aria-label="Open Chat" title="Open Chat" tabindex="0">
+    <button class="floating-icon" id="chatbot-fab-trigger" data-modal="chatbot-modal" aria-label="Open Chat" title="Open Chat" tabindex="0"
+            data-en-label="Open Chat" data-es-label="Abrir Chat"
+            data-en-title="Open Chat" data-es-title="Abrir Chat">
       <i class="fas fa-comments"></i>
     </button>
   </div>

--- a/js/chatbot_creation/chatbot.js
+++ b/js/chatbot_creation/chatbot.js
@@ -5,11 +5,81 @@ function applyTheme(theme) {
   if (theme) document.body.setAttribute('data-theme', theme);
 }
 
+const I18N = {
+  en: {
+    suspiciousActivity: 'Suspicious activity detected. Please reload the page.',
+    lockdownMessage: 'Bot activity detected. Chat disabled.',
+    verifyHuman: 'Please confirm you are human by checking the box.',
+    recaptchaFail: 'reCAPTCHA verification failed. Please try again.',
+    serverError: 'Error verifying message with server. Try again later.',
+    messageBlocked: 'Message blocked for security reasons.',
+    defaultReply: 'Thanks for your message! A support agent will be with you shortly.',
+    hello: 'Hello! How can I help you today?',
+    help: 'I can help with general questions. For specific account issues, an agent will assist you. What do you need help with?',
+    pricing: 'Please see our pricing on the main website or contact sales.',
+    bye: 'Goodbye! Have a great day.',
+    intro: "Hello I'm Chattia",
+    verifyBottom: 'At the bottom; please verify you are human'
+  },
+  es: {
+    suspiciousActivity: 'Actividad sospechosa detectada. Por favor recarga la página.',
+    lockdownMessage: 'Actividad de bot detectada. Chat deshabilitado.',
+    verifyHuman: 'Por favor confirma que eres humano marcando la casilla.',
+    recaptchaFail: 'La verificación reCAPTCHA falló. Inténtalo de nuevo.',
+    serverError: 'Error al verificar el mensaje con el servidor. Intenta de nuevo más tarde.',
+    messageBlocked: 'Mensaje bloqueado por razones de seguridad.',
+    defaultReply: '¡Gracias por tu mensaje! Un agente de soporte te ayudará en breve.',
+    hello: '¡Hola! ¿Cómo puedo ayudarte hoy?',
+    help: 'Puedo ayudar con preguntas generales. Para asuntos de cuenta, un agente te asistirá. ¿Con qué necesitas ayuda?',
+    pricing: 'Consulta nuestros precios en el sitio principal o contacta ventas.',
+    bye: '¡Adiós! Que tengas un gran día.',
+    intro: 'Hola, soy Chattia',
+    verifyBottom: 'Al final, verifica que eres humano'
+  }
+};
+
+let currentLang = document.documentElement.lang || 'en';
+
+let form, input, log, sendBtn, honeypotInput, humanCheckbox;
+
+function t(key) {
+  return (I18N[currentLang] && I18N[currentLang][key]) || I18N.en[key] || key;
+}
+
+function applyI18n() {
+  if (typeof input !== 'undefined') {
+    const ph = input.dataset[currentLang + 'Placeholder'] || input.placeholder;
+    input.placeholder = ph;
+    const lab = input.dataset[currentLang + 'Label'];
+    if (lab) input.setAttribute('aria-label', lab);
+  }
+  if (typeof sendBtn !== 'undefined') {
+    const text = sendBtn.dataset[currentLang] || sendBtn.textContent;
+    sendBtn.textContent = text;
+    const label = sendBtn.dataset[currentLang + 'Label'];
+    if (label) sendBtn.setAttribute('aria-label', label);
+  }
+  const recaptchaSpan = document.querySelector('.recaptcha-text');
+  if (recaptchaSpan) {
+    const txt = recaptchaSpan.dataset[currentLang] || recaptchaSpan.textContent;
+    recaptchaSpan.textContent = txt;
+  }
+}
+
+function setLanguage(lang) {
+  if (!lang) return;
+  currentLang = lang;
+  document.documentElement.lang = lang;
+  applyI18n();
+}
+
 window.addEventListener('message', (event) => {
   if (event.origin !== window.location.origin) return;
   const data = event.data || {};
   if (data.type === 'theme-change') {
     applyTheme(data.theme);
+  } else if (data.type === 'language-change') {
+    setLanguage(data.lang);
   }
 });
 
@@ -17,20 +87,24 @@ document.addEventListener('DOMContentLoaded', () => {
   try {
     const parentTheme = window.parent.document.body.getAttribute('data-theme');
     applyTheme(parentTheme || 'light');
+    const parentLang = window.parent.document.documentElement.getAttribute('lang');
+    if (parentLang) setLanguage(parentLang);
   } catch (err) {
     console.warn('Unable to sync theme with parent on load.', err);
   }
-  const form = document.getElementById('chat-form');
-  const input = document.getElementById('chat-input');
-  const log = document.getElementById('chat-log');
-  const sendBtn = form ? form.querySelector('[type="submit"]') : null;
-  const honeypotInput = form ? form.querySelector('[name="chatbot-honeypot"]') : null;
-  const humanCheckbox = document.getElementById('human-verification-checkbox');
+  form = document.getElementById('chat-form');
+  input = document.getElementById('chat-input');
+  log = document.getElementById('chat-log');
+  sendBtn = form ? form.querySelector('[type="submit"]') : null;
+  honeypotInput = form ? form.querySelector('[name="chatbot-honeypot"]') : null;
+  humanCheckbox = document.getElementById('human-verification-checkbox');
 
   if (!form || !input || !log) {
     console.error('ERROR: Core chatbot UI elements not found in iframe.');
     return;
   }
+
+  applyI18n();
 
   let lockedForBot = false;
 
@@ -53,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function lockDownChat(reason = "Bot activity detected. Chat disabled.") {
+  function lockDownChat(reason = t('lockdownMessage')) {
     input.disabled = true;
     sendBtn && (sendBtn.disabled = true);
     humanCheckbox && (humanCheckbox.disabled = true);
@@ -91,7 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (honeypotInput) {
     honeypotInput.addEventListener('input', () => {
       if (honeypotInput.value !== '' && !lockedForBot) {
-        lockDownChat("Suspicious activity detected. Please reload the page.");
+        lockDownChat(t('suspiciousActivity'));
         alertWorkerOfBotActivity("honeypot filled (input)");
       }
     });
@@ -103,14 +177,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Honeypot check
     if (honeypotInput && honeypotInput.value !== '') {
-      lockDownChat("Suspicious activity detected. Please reload the page.");
+      lockDownChat(t('suspiciousActivity'));
       alertWorkerOfBotActivity("honeypot filled (submit)");
       return;
     }
 
     // Human check
     if (!humanCheckbox || !humanCheckbox.checked) {
-      addMessage("Please confirm you are human by checking the box.", 'bot');
+      addMessage(t('verifyHuman'), 'bot');
       setHumanInteractionState(false);
       return;
     }
@@ -120,7 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       recaptchaToken = await grecaptcha.execute('YOUR_SITE_KEY', { action: 'chatbot_message' });
     } catch (err) {
-      addMessage("reCAPTCHA verification failed. Please try again.", 'bot');
+      addMessage(t('recaptchaFail'), 'bot');
       return;
     }
 
@@ -142,11 +216,11 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       const result = await response.json();
       if (!result.success) {
-        addMessage(result.message || "Message blocked for security reasons.", 'bot');
+        addMessage(result.message || t('messageBlocked'), 'bot');
         return;
       }
     } catch (err) {
-      addMessage("Error verifying message with server. Try again later.", 'bot');
+      addMessage(t('serverError'), 'bot');
       return;
     }
 
@@ -156,26 +230,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function getSimulatedBotReply(userInput) {
     const lowerInput = userInput.toLowerCase();
-    let botResponse = "Thanks for your message! A support agent will be with you shortly.";
+    let botResponse = t('defaultReply');
     if (lowerInput.includes('hello') || lowerInput.includes('hi')) {
-      botResponse = "Hello! How can I help you today?";
+      botResponse = t('hello');
     } else if (lowerInput.includes('help')) {
-      botResponse = "I can help with general questions. For specific account issues, an agent will assist you. What do you need help with?";
+      botResponse = t('help');
     } else if (lowerInput.includes('price') || lowerInput.includes('pricing')) {
-      botResponse = "Please see our pricing on the main website or contact sales.";
+      botResponse = t('pricing');
     } else if (lowerInput.includes('bye')) {
-      botResponse = "Goodbye! Have a great day.";
+      botResponse = t('bye');
     }
     setTimeout(() => addMessage(botResponse, 'bot'), 700);
   }
 
   setTimeout(() => {
-    // The user requested literal strings including the [data=...] parts.
-    if (document.documentElement.lang === 'es') {
-      addMessage("Hola, soy Chattia", 'bot');
-    } else {
-      addMessage("Hello I'm Chattia", 'bot');
-    }
-    addMessage("At the bottom; please verify you are human", 'bot');
+    addMessage(t('intro'), 'bot');
+    addMessage(t('verifyBottom'), 'bot');
   }, 500);
 });

--- a/js/pages/contact_us.js
+++ b/js/pages/contact_us.js
@@ -3,6 +3,39 @@
 
 import { sanitizeInput } from '../utils/sanitize.js';
 
+const I18N = {
+    en: {
+        submissionUnavailable: 'Form submission is currently unavailable.',
+        fillRequired: 'Please fill out all required fields.',
+        honeypot: 'Your submission could not be processed at this time. Please try again later.',
+        success: 'Thank you for contacting us! We\u2019ll get back to you shortly.',
+        error: 'There was a problem sending your message: {{err}}. Please try again later.'
+    },
+    es: {
+        submissionUnavailable: 'El env\u00edo del formulario no est\u00e1 disponible.',
+        fillRequired: 'Por favor complete todos los campos requeridos.',
+        honeypot: 'No pudimos procesar su env\u00edo en este momento. Por favor intente nuevamente m\u00e1s tarde.',
+        success: '\u00a1Gracias por contactarnos! Nos pondremos en contacto pronto.',
+        error: 'Hubo un problema enviando su mensaje: {{err}}. Por favor intente nuevamente m\u00e1s tarde.'
+    }
+};
+
+let currentLang = localStorage.getItem('language') || 'en';
+
+function t(key, replacements = {}) {
+    const str = (I18N[currentLang] && I18N[currentLang][key]) || I18N.en[key] || key;
+    return str.replace('{{err}}', replacements.err || '');
+}
+
+const langObserver = new MutationObserver(mutations => {
+    for (const m of mutations) {
+        if (m.type === 'attributes' && m.attributeName === 'lang') {
+            currentLang = document.documentElement.getAttribute('lang') || 'en';
+        }
+    }
+});
+langObserver.observe(document.documentElement, { attributes: true });
+
 const workerUrl = window.CONTACT_WORKER_URL || "";
 
 function initializeContactModal(modalElement) {
@@ -37,11 +70,11 @@ function initializeContactModal(modalElement) {
         console.warn('Contact form submission disabled: workerUrl not configured.');
         if (submitButton) {
             submitButton.disabled = true;
-            submitButton.title = 'Submission disabled: service unavailable';
+            submitButton.title = t('submissionUnavailable');
         }
         contactForm.addEventListener('submit', (event) => {
             event.preventDefault();
-            alert('Form submission is currently unavailable.');
+            alert(t('submissionUnavailable'));
         });
         return;
     }
@@ -66,14 +99,14 @@ function initializeContactModal(modalElement) {
         });
 
         if (!allRequiredFilled) {
-            alert('Please fill out all required fields.');
+            alert(t('fillRequired'));
             return;
         }
 
         // Honeypot check
         if (data['hp-field'] && data['hp-field'].trim() !== '') {
             console.warn('WARN:ContactForm/submit: Honeypot field filled — likely bot.');
-            alert('Your submission could not be processed at this time. Please try again later.');
+            alert(t('honeypot'));
             return;
         }
         delete data['hp-field'];
@@ -92,12 +125,12 @@ function initializeContactModal(modalElement) {
                 throw new Error(`Network response was not ok: ${response.status} ${response.statusText}. Worker message: ${errorData}`);
             }
 
-            alert('Thank you for contacting us! We\u2019ll get back to you shortly.');
+            alert(t('success'));
             contactForm.reset();
             modalElement.classList.remove('active');
         } catch (error) {
             console.error('ERROR:ContactForm/submit:', error);
-            alert(`There was a problem sending your message: ${error.message}. Please try again later.`);
+            alert(t('error', { err: error.message }));
         }
     });
 

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -233,6 +233,21 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     }
 
+    function updateHeadLanguageTexts(lang) {
+        const headElements = document.head.querySelectorAll('[data-en], [data-es], [data-en-content], [data-es-content]');
+        headElements.forEach(el => {
+            const targetLang = lang;
+            const fallbackLang = 'en';
+            if (el.tagName === 'TITLE') {
+                const text = el.dataset[targetLang] || el.dataset[fallbackLang];
+                if (text !== undefined) el.textContent = text;
+            } else if (el.tagName === 'META' && el.getAttribute('name') === 'description') {
+                const contentText = el.dataset[targetLang + 'Content'] || el.dataset[fallbackLang + 'Content'];
+                if (contentText !== undefined) el.setAttribute('content', contentText);
+            }
+        });
+    }
+
     function setLanguageButtonVisuals() {
         const newButtonText = (currentLanguage === "en") ? "ES" : "EN";
         // ARIA labels for global toggles should ideally have data-attributes themselves for full translation
@@ -258,6 +273,7 @@ document.addEventListener("DOMContentLoaded", () => {
             currentLanguage = newLang;
             localStorage.setItem("language", currentLanguage);
             updateNodeLanguageTexts(currentLanguage, document.body);
+            updateHeadLanguageTexts(currentLanguage);
             setLanguageButtonVisuals(); // Updates global toggle buttons
             console.log(`INFO:Main/masterToggleLanguage: Language changed to ${currentLanguage.toUpperCase()}`);
         }
@@ -273,6 +289,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Initial language setup on page load (will be reapplied/scoped after mobile nav load)
     updateNodeLanguageTexts(currentLanguage, document.body); // Initial full-page scan
+    updateHeadLanguageTexts(currentLanguage);
     setLanguageButtonVisuals(); // For desktop buttons primarily at this stage
     console.log(`INFO:Main/LangInit: Initial language set to ${currentLanguage.toUpperCase()}`);
 
@@ -287,7 +304,9 @@ document.addEventListener("DOMContentLoaded", () => {
     function applyTheme(theme) {
         bodyElement.setAttribute("data-theme", theme);
         localStorage.setItem("theme", theme);
-        const buttonText = (theme === "light") ? "Dark" : "Light";
+        const buttonText = (theme === "light") ?
+            (themeToggleDesktop?.dataset[currentLanguage + 'Dark'] || (currentLanguage === 'es' ? 'Oscuro' : 'Dark')) :
+            (themeToggleDesktop?.dataset[currentLanguage + 'Light'] || (currentLanguage === 'es' ? 'Claro' : 'Light'));
 
         // Update desktop toggle
         const desktopAriaLabel = (theme === 'light') ?
@@ -303,8 +322,11 @@ document.addEventListener("DOMContentLoaded", () => {
         const mobileAriaLabel = (theme === 'light') ?
             (mobileThemeToggle?.dataset[currentLanguage + 'LabelDark'] || mobileThemeToggle?.dataset['enLabelDark'] || "Switch to Dark Theme") :
             (mobileThemeToggle?.dataset[currentLanguage + 'LabelLight'] || mobileThemeToggle?.dataset['enLabelLight'] || "Switch to Light Theme");
+        const mobileText = (theme === 'light') ?
+            (mobileThemeToggle?.dataset[currentLanguage + 'Dark'] || buttonText) :
+            (mobileThemeToggle?.dataset[currentLanguage + 'Light'] || buttonText);
         if (mobileThemeToggle) {
-            mobileThemeToggle.textContent = buttonText;
+            mobileThemeToggle.textContent = mobileText;
              if(mobileAriaLabel) mobileThemeToggle.setAttribute('aria-label', mobileAriaLabel);
         }
         console.log(`INFO:Main/applyTheme: Theme set to ${theme}`);

--- a/offline.html
+++ b/offline.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Offline - OPS Solutions Services</title>
+  <title data-en="Offline - OPS Solutions Services" data-es="Sin Conexión - OPS Solutions Services">Offline - OPS Solutions Services</title>
   <link rel="stylesheet" href="css/base/global.css">
   <link rel="stylesheet" href="css/base/small-screens.css">
 </head>
 <body>
   <main style="padding:2rem;text-align:center;">
-    <h1>You are offline</h1>
-    <p>The page you requested is unavailable. Please check your connection and try again.</p>
+    <h1 data-en="You are offline" data-es="Estás sin conexión">You are offline</h1>
+    <p data-en="The page you requested is unavailable. Please check your connection and try again." data-es="La página que solicitaste no está disponible. Por favor verifica tu conexión e inténtalo de nuevo.">The page you requested is unavailable. Please check your connection and try again.</p>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add bilingual `data-en` and `data-es` values for page titles and meta descriptions
- update language toggle logic to modify head elements
- internationalize contact form alert messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68644116e144832b8b86fb39f09b40ce