### PR TITLE
Fix: Improve mobile nav loading and diagnostics

### DIFF
--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -37,24 +37,32 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             let html = await response.text();
 
+            if (!html || html.trim() === "") {
+                console.error('ERROR:Main/loadMobileNavigation: Fetched mobile_nav.html is empty or invalid.');
+                throw new Error('Fetched mobile_nav.html is empty or invalid.'); // This will be caught by the catch block
+            }
+
             // Correct href paths using ROOT_PATH
             html = html.replace(/href="html\//g, `href="${ROOT_PATH}html/`);
             html = html.replace(/href="index\.html"/g, `href="${ROOT_PATH}index.html"`);
 
             if (mobileNavPlaceholder) {
                 mobileNavPlaceholder.innerHTML = html;
+                console.log('INFO:Main/loadMobileNavigation: Mobile navigation HTML injected into placeholder.');
             } else {
                 // Fallback if placeholder is missing, append to body
+                console.warn('WARN:Main/loadMobileNavigation: mobile-nav-placeholder not found, appending to body.');
                 const tempDiv = document.createElement('div');
                 tempDiv.innerHTML = html;
                 while (tempDiv.firstChild) {
                     document.body.appendChild(tempDiv.firstChild);
                 }
+                console.log('INFO:Main/loadMobileNavigation: Mobile navigation HTML appended to body.');
             }
-            console.log('INFO:Main/loadMobileNavigation: Mobile navigation HTML loaded and injected.');
             return true;
         } catch (error) {
-            console.error('ERROR:Main/loadMobileNavigation:', error);
+            // Log the specific error from the try block, or the generic fetch error
+            console.error(`ERROR:Main/loadMobileNavigation: ${error.message}`);
             return false;
         }
     }


### PR DESCRIPTION
- Enhanced `loadMobileNavigation` in `js/pages/main.js` to check for empty or invalid HTML content from `mobile_nav.html`.
- Added more specific error logging if `mobile_nav.html` is empty, fails to fetch, or if the mobile nav placeholder is missing.
- Added a console log to confirm successful HTML injection for the mobile navigation.
- Verified CSS rules using `grep`; no unexpected overrides found that would hide the mobile navigation on small screens.

These changes aim to make the mobile navigation loading more robust and provide better diagnostics if it fails to appear.