### PR TITLE
Fix: Enable mobile nav horizontal services menu and modals

### DIFF
--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -171,6 +171,34 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     */ // END OLD - initializeMobileNavInteractions
 
+    // START: MODIFIED FOR STEP 3 - Ensure mobile-services-toggle functionality
+    // Mobile Services Menu Toggle (for the old mobile_nav.html's bottom nav menu)
+    const mobileServicesToggle = document.getElementById('mobile-services-toggle');
+    const mobileServicesMenu = document.getElementById('mobile-services-menu');
+
+    if (mobileServicesToggle && mobileServicesMenu) {
+        mobileServicesToggle.addEventListener('click', () => {
+            const isOpen = mobileServicesMenu.classList.toggle('active');
+            mobileServicesToggle.setAttribute('aria-expanded', isOpen.toString());
+            mobileServicesMenu.setAttribute('aria-hidden', (!isOpen).toString());
+        });
+
+        // Optional: Close menu when clicking outside
+        document.addEventListener('click', (event) => {
+            if (mobileServicesMenu.classList.contains('active')) {
+                if (!mobileServicesMenu.contains(event.target) && !mobileServicesToggle.contains(event.target)) {
+                    mobileServicesMenu.classList.remove('active');
+                    mobileServicesToggle.setAttribute('aria-expanded', 'false');
+                    mobileServicesMenu.setAttribute('aria-hidden', 'true');
+                }
+            }
+        });
+    } else {
+        // console.warn('WARN:Main/MobileServicesToggle: Mobile services toggle or menu not found (mobile_nav.html).');
+        // This warning might appear on pages not using mobile_nav.html, which is fine.
+    }
+    // END: MODIFIED FOR STEP 3
+
     // Dynamically set the Home link in the rightSideMenu
     const homeLinkRightSideMenu = document.querySelector("#rightSideMenu .right-side-menu-nav a[href='../index.html']");
     if (homeLinkRightSideMenu) {


### PR DESCRIPTION
Re-enabled the toggle functionality for the services menu within the legacy mobile navigation (`mobile_nav.html`). This allows the service items (e.g., Business Operations, IT Support) within this menu to be accessed and trigger their respective modals.

The modal opening itself relies on the existing generic `data-modal` handler in `main.js`. This change ensures that the menu becomes visible, making its links clickable.