### PR TITLE
Sanitize input handling

### DIFF
--- a/js/chatbot_creation/chatbot.js
+++ b/js/chatbot_creation/chatbot.js
@@ -208,13 +208,14 @@ document.addEventListener('DOMContentLoaded', () => {
     let userInput = input.value.trim();
     if (!userInput) return;
 
-    const sanitizedUserMessage = sanitizeInput(userInput);
-    if (userInput !== sanitizedUserMessage) {
+    const { sanitized, flagged } = sanitizeInput(userInput);
+    if (userInput !== sanitized) {
         console.warn("Chatbot: User input was modified by sanitizer.");
-        // Decide if you want to inform the user or just use the sanitized version.
-        // For now, we'll use the sanitized version silently.
     }
-    userInput = sanitizedUserMessage; // Use the sanitized input
+    if (flagged) {
+        console.warn("Chatbot: user input flagged for potential sensitive content.");
+    }
+    userInput = sanitized; // Use the sanitized input
 
     addMessage(userInput, 'user');
     input.value = '';

--- a/js/pages/contact_us.js
+++ b/js/pages/contact_us.js
@@ -77,7 +77,11 @@ function initializeContactModal(modalElement) {
 
         // Sanitize & collect
         for (const [key, value] of formData.entries()) {
-            data[key] = sanitizeInput(value);
+            const { sanitized, flagged } = sanitizeInput(value);
+            data[key] = sanitized;
+            if (flagged) {
+                console.warn(`sanitizeInput flagged input for field ${key}`);
+            }
         }
 
         // Required field validation


### PR DESCRIPTION
## Summary
- use `sanitizeInput(...).sanitized` when collecting contact form fields
- log flagged input in contact form
- handle `flagged` boolean in chatbot user messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c1918ca4832babe233f6bc2b3445