### PR TITLE
Fix FAB modal loading

### DIFF
--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -1,8 +1,59 @@
 // js/pages/main.js
 
+import { initializeContactModal } from './contact_us.js';
+import { initializeJoinUsModal } from './join_us.js';
+import { initializeChatbotModal } from './chatbot.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const body = document.body;
   const html = document.documentElement;
+
+  // Map modal IDs to their corresponding HTML fragment
+  const modalMap = {
+    'contact-modal': 'contact_us_modal.html',
+    'join-us-modal': 'join_us_modal.html',
+    'chatbot-modal': 'chatbot_modal.html',
+    'business-operations-service-modal': 'business_operations_modal.html',
+    'contact-center-service-modal': 'contact_center_modal.html',
+    'it-support-service-modal': 'it_support_modal.html',
+    'professionals-service-modal': 'professionals_modal.html',
+    'generic-service-modal': 'generic_service_modal.html'
+  };
+
+  async function loadModal(modalId) {
+    const existing = document.getElementById(modalId);
+    if (existing) return existing;
+
+    const placeholder = document.getElementById(`${modalId}-placeholder`);
+    const file = modalMap[modalId];
+    if (!placeholder || !file) return null;
+
+    try {
+      const resp = await fetch(`html/modals/${file}`);
+      if (!resp.ok) throw new Error(`Failed to fetch ${file}`);
+      placeholder.innerHTML = await resp.text();
+      const modal = document.getElementById(modalId);
+      // Initialize modal specific scripts
+      if (modalId === 'contact-modal') initializeContactModal(modal);
+      if (modalId === 'join-us-modal') initializeJoinUsModal(modal);
+      if (modalId === 'chatbot-modal') initializeChatbotModal(modal);
+      attachModalClose(modal);
+      return modal;
+    } catch (err) {
+      console.error('Modal load failed:', err);
+      return null;
+    }
+  }
+
+  function attachModalClose(modal) {
+    if (!modal) return;
+    modal.addEventListener('click', (e) => {
+      const target = e.target;
+      if (target.classList.contains('modal') || target.hasAttribute('data-close')) {
+        modal.classList.remove('active');
+      }
+    });
+  }
 
   // Safe utility to dispatch custom events
   function dispatchSafeEvent(name, detail = {}) {
@@ -63,27 +114,21 @@ document.addEventListener('DOMContentLoaded', () => {
   // Modals: Open Handler
   document.querySelectorAll('[data-modal]').forEach(button => {
     const modalId = button.getAttribute('data-modal');
-    const modal = document.getElementById(modalId);
-    if (modal) {
-      button.addEventListener('click', () => {
+    button.addEventListener('click', async () => {
+      let modal = document.getElementById(modalId);
+      if (!modal) modal = await loadModal(modalId);
+      if (modal) {
         modal.classList.add('active');
         setTimeout(() => {
           const focusable = modal.querySelector('input, textarea, button');
           if (focusable) focusable.focus();
         }, 100);
-      });
-    }
-  });
-
-  // Modals: Close Handler
-  document.querySelectorAll('.modal').forEach(modal => {
-    modal.addEventListener('click', (e) => {
-      const target = e.target;
-      if (target.classList.contains('modal') || target.hasAttribute('data-close')) {
-        modal.classList.remove('active');
       }
     });
   });
+
+  // Modals: Close Handler
+  document.querySelectorAll('.modal').forEach(attachModalClose);
 
   // Sync saved theme
   const savedTheme = localStorage.getItem('theme');


### PR DESCRIPTION
## Summary
- load modal HTML fragments on demand when FABs are clicked
- initialise relevant modal scripts after loading
- attach close handlers dynamically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c23bd2c8832ba1521cc59316066a