### PR TITLE
Adjust Chattia widget layout

### DIFF
--- a/css/chatbot_creation/chatbot-ui.css
+++ b/css/chatbot_creation/chatbot-ui.css
@@ -54,7 +54,7 @@ body[data-theme="dark"] .bot-message {
 /* Chat Input Form */
 .chat-form {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   padding: 10px;
   background-color: #f8f9fa;
   border-top: 1px solid #ccc;
@@ -68,11 +68,10 @@ body[data-theme="dark"] .chat-form {
 
 /* Text Input */
 #chat-input {
-  flex-grow: 1;
+  width: 100%;
   padding: 10px;
   border: 1px solid #ccc;
   border-radius: 20px;
-  margin-right: 10px;
   background-color: ghostwhite;
   color: #333;
   font-size: 0.95rem;
@@ -86,6 +85,7 @@ body[data-theme="dark"] #chat-input {
 
 /* Send Button */
 #chat-send-button {
+  align-self: flex-start;
   padding: 10px 15px;
   background-color: lemonchiffon;
   color: #333;
@@ -153,13 +153,7 @@ body[data-theme="dark"] .recaptcha-placeholder-container {
 /* Responsive Fixes */
 @media (max-width: 480px) {
   .chat-form {
-    flex-direction: column;
     gap: 6px;
-  }
-
-  #chat-input {
-    margin-right: 0;
-    width: 100%;
   }
 
   #chat-send-button {

--- a/html/chatbot_creation/chatbot-widget.html
+++ b/html/chatbot_creation/chatbot-widget.html
@@ -36,6 +36,11 @@
     <div id="chat-log" class="chat-log" aria-live="polite" aria-label="Chat conversation area"></div>
 
     <form id="chat-form" class="chat-form" autocomplete="off" aria-label="Chatbot form">
+      <!-- User Input -->
+      <input type="text" id="chat-input"
+        placeholder="Ask me anything..."
+        aria-label="Ask me anything..." required />
+
       <!-- Human Verification -->
       <div class="recaptcha-placeholder-container" id="recaptcha-inline-placeholder">
         <label for="human-verification-checkbox" class="recaptcha-label"
@@ -46,19 +51,14 @@
         </label>
       </div>
 
-      <!-- User Input -->
-      <input type="text" id="chat-input"
-        placeholder="Ask me anything..."
-        aria-label="Ask me anything..." required />
-
-      <!-- Honeypot Field -->
-      <input type="text" name="chatbot-honeypot" class="ops-chatbot-honeypot-field"
-        tabindex="-1" aria-hidden="true" />
-
       <!-- Send Button -->
       <button type="submit" id="chat-send-button"
         aria-label="Send Message"
         data-en-label="Send Message" data-es-label="Enviar Mensaje">Send</button>
+
+      <!-- Honeypot Field -->
+      <input type="text" name="chatbot-honeypot" class="ops-chatbot-honeypot-field"
+        tabindex="-1" aria-hidden="true" />
     </form>
 
     <!-- Future STT placeholder for Whisper.js -->


### PR DESCRIPTION
## Summary
- move message input above human verification in widget
- show SEND button on bottom left
- update layout styles for column flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867cf422e18832b86bdb5917b197ec9