### PR TITLE
Fix language toggle labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,25 @@
     </nav>
     <div class="header-controls">
       <div class="toggle-container">
-        <button id="theme-toggle-desktop">Light</button>
-        <button id="language-toggle-desktop">EN</button>
+        <button id="theme-toggle-desktop"
+                class="theme-toggle-btn"
+                title="Toggle Theme"
+                aria-label="Toggle Theme"
+                data-en-label-dark="Switch to Dark Theme"
+                data-es-label-dark="Cambiar a Tema Oscuro"
+                data-en-label-light="Switch to Light Theme"
+                data-es-label-light="Cambiar a Tema Claro"
+                data-en-dark="Dark"
+                data-es-dark="Oscuro"
+                data-en-light="Light"
+                data-es-light="Claro">Light</button>
+
+        <button id="language-toggle-desktop"
+                class="lang-toggle-btn"
+                title="Switch Language"
+                aria-label="Switch Language"
+                data-en-label="Switch to Spanish"
+                data-es-label="Cambiar a Inglés">EN</button>
       </div>
       <button id="menu-open" class="header-menu-trigger" aria-label="Open Menu">
         <i class="fas fa-bars"></i>

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -97,11 +97,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (span) span.textContent = text; else btn.textContent = text;
   }
 
-  function updateLanguageButton(btn, lang) {
+  function updateLanguageButton(btn, targetLang) {
     if (!btn) return;
     const span = btn.querySelector('span');
-    const text = lang === 'en' ? (btn.dataset.en || 'EN') : (btn.dataset.es || 'ES');
-    const label = lang === 'en' ? (btn.dataset.enLabel || 'Switch to Spanish') : (btn.dataset.esLabel || 'Cambiar a Inglés');
+    const text = targetLang === 'en' ? (btn.dataset.en || 'EN') : (btn.dataset.es || 'ES');
+    const activeLang = document.documentElement.getAttribute('lang') === 'es' ? 'es' : 'en';
+    const label = activeLang === 'en'
+      ? (btn.dataset.enLabel || 'Switch to Spanish')
+      : (btn.dataset.esLabel || 'Cambiar a Inglés');
     if (label) {
       btn.setAttribute('title', label);
       btn.setAttribute('aria-label', label);


### PR DESCRIPTION
## Summary
- adjust language toggle to show correct labels based on current language
- add translation metadata for theme and language buttons on `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867d75444d0832b8652a19a09e986f4