### PR TITLE
Feat: Ensure dynamic modal content respects language selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,10 @@
   <link rel="stylesheet" href="css/modals/contact_us_modal.css">
   <link rel="stylesheet" href="css/modals/join_us_modal.css">
   <link rel="stylesheet" href="css/modals/chatbot_modal.css">
+  <link rel="stylesheet" href="css/modals/business_operations_modal.css">
+  <link rel="stylesheet" href="css/modals/contact_center_modal.css">
+  <link rel="stylesheet" href="css/modals/it_support_modal.css">
+  <link rel="stylesheet" href="css/modals/professionals_modal.css">
 
   <!-- Font Awesome -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha384-blOohCVdhjmtROpu8+CfTnUWham9nkX7P7OZQMst+RUnhtoY/9qemFAkIKOYxDI3" crossorigin="anonymous">

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -73,6 +73,14 @@ document.addEventListener('DOMContentLoaded', () => {
       if (modalId === 'contact-modal') initializeContactModal(modal);
       if (modalId === 'join-us-modal') initializeJoinUsModal(modal);
       if (modalId === 'chatbot-modal') initializeChatbotModal(modal);
+
+      if (modal && !modal.classList.contains('active')) {
+          modal.setAttribute('aria-hidden', 'true');
+      }
+      // Apply current language to the newly loaded modal content
+      if (modal && typeof updateDynamicContentLanguage === 'function') {
+        updateDynamicContentLanguage(modal);
+      }
       attachModalClose(modal);
       return modal;
     } catch (err) {
@@ -89,6 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (target === modal || target.classList.contains('modal-overlay') ||
           target.hasAttribute('data-close')) {
         modal.classList.remove('active');
+        modal.setAttribute('aria-hidden', 'true');
       }
     });
   }
@@ -236,6 +245,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!modal) modal = await loadModal(modalKey);
       if (modal) {
         modal.classList.add('active');
+        modal.setAttribute('aria-hidden', 'false');
         setTimeout(() => {
           const focusable = modal.querySelector('input, textarea, button');
           if (focusable) focusable.focus();
@@ -250,7 +260,10 @@ document.addEventListener('DOMContentLoaded', () => {
   // Close active modal on Escape key press
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
-      document.querySelectorAll('.modal-overlay.active').forEach(m => m.classList.remove('active'));
+      document.querySelectorAll('.modal-overlay.active').forEach(m => {
+        m.classList.remove('active');
+        m.setAttribute('aria-hidden', 'true');
+      });
     }
   });
 


### PR DESCRIPTION
- Modified `js/pages/main.js` to call `updateDynamicContentLanguage` on newly loaded modal content within the `loadModal` function.
- This ensures that when a modal is fetched and displayed for the first time, its translatable text elements are immediately updated to the currently selected application language (English or Spanish).