### PR TITLE
Fix: Correct FAB mobile navigation layout issues

### DIFF
--- a/css/base/small-screens.css
+++ b/css/base/small-screens.css
@@ -258,9 +258,11 @@
     border: none;
     font-size: 0.75rem; /* Text size from example */
     cursor: pointer;
-    padding: 0; /* Remove previous padding if any */
+    padding: 0; /* Override global.css padding */
     width: auto; /* Fit content */
+    min-width: initial; /* Override global.css min-width: 60px */
     text-align: center;
+    flex-shrink: 0; /* Prevent items from shrinking if container is too small */
   }
 
   .horiz-nav-item i {


### PR DESCRIPTION
- Resolved issue where navigation items (.horiz-nav-item) could appear outside the navigation menu container (#horizontalMobileNav). This was caused by a `min-width` style from global.css; it's now overridden with `min-width: initial;` in small-screens.css for the FAB context.
- Added `flex-shrink: 0` to `.horiz-nav-item` for robustness.
- Verified CSS for `#horizontalNavFab` (FAB toggle) ensures `position: fixed; bottom: 20px; right: 20px;`.
- Verified CSS for `#horizontalServicesMenu` (services submenu) ensures `position: fixed; bottom: 90px; right: 20px;`.
- Confirmed JavaScript logic only toggles visibility classes and does not interfere with CSS positioning.