### PR TITLE
Fix: Adjust modal CSS for 80% width on small screens

### DIFF
--- a/css/modals/business_operations_modal.css
+++ b/css/modals/business_operations_modal.css
@@ -29,11 +29,11 @@ body[data-theme="dark"] #business-operations-modal .modal-content {
 
 @media (max-width: 768px) {
   #business-operations-modal .modal-content {
-    width: 100%;
-    max-width: 100%;
-    height: 100%;
-    border-radius: 0;
-    padding: 1rem;
+    /* width: 100%; */ /* Let global small-screen styles apply */
+    /* max-width: 100%; */ /* Let global small-screen styles apply */
+    /* height: 100%; */ /* Let global small-screen styles apply */
+    border-radius: 0; /* This can remain if desired for a specific look */
+    padding: 1rem; /* This can remain */
   }
 
   #business-operations-modal .modal-body p {

--- a/css/modals/chatbot_modal.css
+++ b/css/modals/chatbot_modal.css
@@ -50,3 +50,14 @@ body[data-theme="dark"] #chatbot-modal .modal-footer {
   background-color: #2a2a2a;
   border-top-color: #444;
 }
+
+/* === Responsive for Mobile Devices === */
+@media (max-width: 768px) {
+  #chatbot-modal .modal-content {
+    /* Override specific height settings to align with global small-screen behavior */
+    height: auto;
+    max-height: 80vh; /* Or inherit from .modal-content in small-screens.css if preferred */
+     /* width: 80% and max-width: 80% will be inherited from css/base/small-screens.css */
+     /* Its own max-width: 500px will still apply if screen 80% is larger than 500px */
+  }
+}

--- a/css/modals/contact_center_modal.css
+++ b/css/modals/contact_center_modal.css
@@ -25,14 +25,14 @@ body[data-theme="dark"] #contact-center-modal .modal-content {
 /* === Responsive for Mobile Devices === */
 @media (max-width: 768px) {
   #contact-center-modal .modal-content {
-    width: 100%;
-    max-width: 100%;
-    height: 100%;
-    max-height: 100vh;
-    border-radius: 0;
-    padding: 0;
-    border: none;
-    box-shadow: none;
+    /* width: 100%; */ /* Let global small-screen styles apply */
+    /* max-width: 100%; */ /* Let global small-screen styles apply */
+    /* height: 100%; */ /* Let global small-screen styles apply */
+    /* max-height: 100vh; */ /* Let global small-screen styles apply (80vh) */
+    border-radius: 0; /* This can remain if desired */
+    padding: 0; /* This can remain if desired, but base provides padding */
+    border: none; /* This can remain if desired */
+    box-shadow: none; /* This can remain if desired */
   }
 }
 

--- a/css/modals/contact_us_modal.css
+++ b/css/modals/contact_us_modal.css
@@ -140,34 +140,35 @@ textarea {
 
 /* === Responsive for Mobile Devices === */
 @media (max-width: 768px) {
-  .modal-content {
-    width: 100%;
-    max-width: 100%;
-    height: 100%;
-    max-height: 100vh;
-    padding: 0;
-    border-radius: 0;
-    box-shadow: none;
-    border: none;
+  .modal-content { /* This rule might be too general if this file is loaded after small-screens.css */
+    /* width: 100%; */ /* Let global small-screen styles apply */
+    /* max-width: 100%; */ /* Let global small-screen styles apply */
+    /* height: 100%; */ /* Let global small-screen styles apply */
+    /* max-height: 100vh; */ /* Let global small-screen styles apply (80vh) */
+    /* padding: 0; */ /* Base small-screen styles handle padding if this is removed */
+    /* border-radius: 0; */ /* Base small-screen styles handle border-radius */
+    /* box-shadow: none; */ /* Base small-screen styles handle box-shadow */
+    /* border: none; */ /* Base small-screen styles handle border */
   }
-  .modal-body {
+  /* Specific adjustments for contact_us_modal can remain if they don't conflict with sizing */
+  #contact-modal .modal-body { /* Scoping to the specific modal ID is safer */
     padding: 1rem;
   }
-  .form-cell {
+  #contact-modal .form-cell {
     -ms-flex: 1 1 100%;
     flex: 1 1 100%;
   }
-  .modal-header h3 {
+  #contact-modal .modal-header h3 {
     font-size: 1.25rem;
   }
-  input[type="text"],
-  input[type="email"],
-  input[type="tel"],
-  input[type="date"],
-  input[type="time"],
-  select,
-  textarea,
-  .submit-button {
+  #contact-modal input[type="text"],
+  #contact-modal input[type="email"],
+  #contact-modal input[type="tel"],
+  #contact-modal input[type="date"],
+  #contact-modal input[type="time"],
+  #contact-modal select,
+  #contact-modal textarea,
+  #contact-modal .submit-button {
     font-size: 0.95rem;
   }
 }

--- a/css/modals/join_us_modal.css
+++ b/css/modals/join_us_modal.css
@@ -8,22 +8,22 @@
 
 @media (max-width: 768px) {
   #join-us-modal .modal-content {
-    width: 100%;
-    max-width: 100%;
-    height: 100%;
-    max-height: 100vh;
-    padding: 0;
-    border-radius: 0;
-    box-shadow: none;
-    border: none;
+    /* width: 100%; */ /* Let global small-screen styles apply */
+    /* max-width: 100%; */ /* Let global small-screen styles apply */
+    /* height: 100%; */ /* Let global small-screen styles apply */
+    /* max-height: 100vh; */ /* Let global small-screen styles apply (80vh) */
+    /* padding: 0; */ /* Base small-screen styles handle padding */
+    /* border-radius: 0; */ /* Base small-screen styles handle border-radius */
+    /* box-shadow: none; */ /* Base small-screen styles handle box-shadow */
+    /* border: none; */ /* Base small-screen styles handle border */
   }
 
   #join-us-modal .modal-body {
-    padding: 1rem;
+    padding: 1rem; /* This specific padding can remain */
   }
 
   #join-us-modal .modal-body .form-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr; /* This layout adjustment can remain */
   }
 }
 

--- a/css/modals/professionals_modal.css
+++ b/css/modals/professionals_modal.css
@@ -47,22 +47,22 @@
 /* Responsive design */
 @media (max-width: 768px) {
   #professionals-modal .modal-content {
-    width: 100%;
-    max-width: 100%;
-    height: 100%;
-    max-height: 100vh;
-    padding: 0;
-    border-radius: 0;
-    box-shadow: none;
-    border: none;
+    /* width: 100%; */ /* Let global small-screen styles apply */
+    /* max-width: 100%; */ /* Let global small-screen styles apply */
+    /* height: 100%; */ /* Let global small-screen styles apply */
+    /* max-height: 100vh; */ /* Let global small-screen styles apply (80vh) */
+    /* padding: 0; */ /* Base small-screen styles handle padding */
+    /* border-radius: 0; */ /* Base small-screen styles handle border-radius */
+    /* box-shadow: none; */ /* Base small-screen styles handle box-shadow */
+    /* border: none; */ /* Base small-screen styles handle border */
   }
 
   #professionals-modal .modal-body {
-    padding: 1rem;
+    padding: 1rem; /* This specific padding can remain */
   }
 
   #professionals-modal .modal-header h3 {
-    font-size: 1.25rem;
+    font-size: 1.25rem; /* This specific font adjustment can remain */
   }
 }
 


### PR DESCRIPTION
- Commented out specific modal CSS overrides for width/height on small screens (<= 768px) to allow base styles (80% width, 80vh max-height) to apply.
- Affected files: business_operations_modal.css, contact_center_modal.css, contact_us_modal.css, join_us_modal.css, professionals_modal.css.
- Added explicit small-screen rules for chatbot_modal.css to ensure height: auto and max-height: 80vh for consistency.
- Scoped some rules in contact_us_modal.css media query to its specific ID.

No changes made to footing colors yet, pending user feedback after testing these modal adjustments.