### PR TITLE
Style: Reduce font and icon sizes in horizontal mobile nav

### DIFF
--- a/css/base/small-screens.css
+++ b/css/base/small-screens.css
@@ -232,7 +232,7 @@
     right: 90px; /* To the left of the FAB */
     display: flex;
     flex-direction: row-reverse; /* Items added to the left */
-    gap: 8px; /* Space between items - Reduced from 10px */
+    gap: 6px; /* Space between items - Further reduced */
     background: var(--bg-current, #fff); /* Use theme variable, fallback to white */
     padding: 0.5rem 1rem; /* Padding from example */
     border-radius: 30px; /* Rounded ends from example */
@@ -256,7 +256,7 @@
     color: var(--text-current, #333); /* Use theme variable */
     background: none;
     border: none;
-    font-size: 0.7rem; /* Text size from example - Reduced from 0.75rem */
+    font-size: 0.6rem; /* Further reduced font size for text */
     cursor: pointer;
     padding: 0; /* Override global.css padding */
     width: auto; /* Fit content */
@@ -266,8 +266,8 @@
   }
 
   .horiz-nav-item i {
-    font-size: 1.2rem; /* Icon size from example - Reduced from 1.4rem */
-    margin-bottom: 2px; /* Space between icon and text, adjust as needed */
+    font-size: 1.0rem; /* Further reduced icon size */
+    margin-bottom: 1px; /* Reduced space between icon and text */
     margin-right: 0; /* Remove previous margin */
     width: auto;
   }


### PR DESCRIPTION
Reduces the font size of text elements and icons within the horizontal expandable mobile navigation menu for screen widths <= 768px.

- Decreased text font size in `.horiz-nav-item` from 0.7rem to 0.6rem.
- Decreased icon font size in `.horiz-nav-item i` from 1.2rem to 1.0rem.
- Adjusted `gap` in `#horizontalMobileNav` from 8px to 6px.
- Adjusted `margin-bottom` for icons in `.horiz-nav-item i` from 2px to 1px.

These changes make the navigation elements more compact on smaller screens.