### PR TITLE
Fix: Enable close buttons for IT Support and Professionals modals

### DIFF
--- a/html/modals/it_support_modal.html
+++ b/html/modals/it_support_modal.html
@@ -16,16 +16,10 @@
           data-es="Soporte IT">
         IT Support
       </h3>
-      <button class="close-modal"
-              data-close
+      <button type="button" class="close-modal" data-close
               aria-label="Close modal"
-               title="Close modal"
-               data-en-label="Close IT Support Modal"
-               data-es-label="Cerrar Modal de Soporte IT"
-               data-en-title="Close IT Support Modal"
-               data-es-title="Cerrar Modal de Soporte IT">
-        <span aria-hidden="true">&times;</span>
-      </button>
+              data-en-label="Close IT Support Modal"
+              data-es-label="Cerrar Modal de Soporte IT">&times;</button>
     </header>
 
     <!-- Modal Body -->
@@ -38,9 +32,7 @@
 
     <!-- Modal Footer -->
     <footer class="modal-footer">
-      <button type="button"
-              class="btn btn-secondary close-modal"
-              data-close
+      <button type="button" class="close-modal" data-close
               data-en="Close"
               data-es="Cerrar">
         Close

--- a/html/modals/professionals_modal.html
+++ b/html/modals/professionals_modal.html
@@ -16,16 +16,10 @@
           data-es="Profesionales">
         Professionals
       </h3>
-      <button class="close-modal"
-              data-close
+      <button type="button" class="close-modal" data-close
               aria-label="Close modal"
-               title="Close modal"
-               data-en-label="Close Professionals Modal"
-               data-es-label="Cerrar Modal de Profesionales"
-               data-en-title="Close Professionals Modal"
-               data-es-title="Cerrar Modal de Profesionales">
-        <span aria-hidden="true">&times;</span>
-      </button>
+              data-en-label="Close Professionals Modal"
+              data-es-label="Cerrar Modal de Profesionales">&times;</button>
     </header>
 
     <!-- Modal Body -->
@@ -38,9 +32,7 @@
 
     <!-- Modal Footer -->
     <footer class="modal-footer">
-      <button type="button"
-              class="close-modal"
-              data-close
+      <button type="button" class="close-modal" data-close
               data-en="Close"
               data-es="Cerrar">
         Close


### PR DESCRIPTION
Standardized the HTML structure of close buttons in IT Support and Professionals modals to match working examples. This includes:
- Adding type="button" to header and footer close buttons.
- Ensuring the &times; entity is a direct child of header close buttons.
- Removing superfluous title attributes from header close buttons.
- Aligning CSS classes on footer close buttons.

These changes ensure consistent behavior and functionality with other modals like Business Operations and Contact Center.