### PR TITLE
Ensure contact form modal markup is consistent

### DIFF
--- a/html/modals/contact_us_modal.html
+++ b/html/modals/contact_us_modal.html
@@ -1,11 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Contact Modal</title>
-  <link rel="stylesheet" href="css/modals/contact_us_modal.css">
-</head>
-<body>
+<!-- Contact Us Modal Markup -->
+<link rel="stylesheet" href="../css/modals/contact_us_modal.css">
   <div id="contact-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="contactModalTitle" aria-hidden="true" tabindex="-1">
     <div class="modal-content" role="document">
 
@@ -119,5 +113,3 @@
 
   <!-- External script to manage modal -->
   <script type="module" src="../../js/pages/contact_us.js" defer></script>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- remove HTML wrapper from `contact_us_modal.html`
- adjust stylesheet path to work across pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869d4187ff8832b84f6d241cd307a1f