### PR TITLE
Enable consistent modal close behavior

### DIFF
--- a/js/pages/contact_us.js
+++ b/js/pages/contact_us.js
@@ -2,6 +2,7 @@
 // Handles multilingual, secure contact form submission with modal management
 
 import { sanitizeInput } from '../utils/sanitize.js';
+import { attachModalHandlers, closeModal } from '../utils/modal.js';
 
 const I18N = {
     en: {
@@ -43,13 +44,8 @@ function initializeContactModal(modalElement) {
     const contactForm = modalElement.querySelector('#contact-form');
     if (!contactForm) return console.error('#contact-form not found.');
 
-    // Close modal on backdrop click or close button
-    modalElement.querySelectorAll('[data-close]').forEach(btn => {
-        btn.addEventListener('click', () => modalElement.classList.remove('active'));
-    });
-    modalElement.addEventListener('click', e => {
-        if (e.target === modalElement) modalElement.classList.remove('active');
-    });
+    // Enable closing via buttons, overlay click and Escape key
+    attachModalHandlers(modalElement);
 
     const submitBtn = contactForm.querySelector('button[type="submit"]');
 
@@ -118,7 +114,7 @@ function initializeContactModal(modalElement) {
 
             alert(t('success'));
             contactForm.reset();
-            modalElement.classList.remove('active');
+            closeModal(modalElement);
         } catch (err) {
             console.error('Submit error:', err);
             alert(t('error', { err: err.message }));

--- a/js/pages/join_us.js
+++ b/js/pages/join_us.js
@@ -1,6 +1,8 @@
 // js/join_us.js
 // Handles Join Us modal dynamic interaction securely
 
+import { attachModalHandlers } from '../utils/modal.js';
+
 function initializeJoinUsModal(modalElement) {
     if (!modalElement) return console.error("ERROR:join_us/initializeJoinUsModal: Modal element not provided.");
 
@@ -9,13 +11,8 @@ function initializeJoinUsModal(modalElement) {
     const joinForm = modalElement.querySelector('#join-us-form-modal');
     if (!joinForm) return console.error("ERROR:join_us: #join-us-form-modal not found.");
 
-    // Close modal on [data-close] elements or overlay click
-    modalElement.querySelectorAll('[data-close]').forEach(btn => {
-        btn.addEventListener('click', () => modalElement.classList.remove('active'));
-    });
-    modalElement.addEventListener('click', e => {
-        if (e.target === modalElement) modalElement.classList.remove('active');
-    });
+    // Enable closing via buttons, overlay click and Escape key
+    attachModalHandlers(modalElement);
 
     joinForm.addEventListener('submit', (e) => {
         e.preventDefault();

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -4,6 +4,7 @@ import { initializeContactModal } from './contact_us.js';
 import { initializeJoinUsModal } from './join_us.js';
 import { initializeChatbotModal } from './chatbot.js';
 import { updateDynamicContentLanguage } from '../utils/i18n.js';
+import { attachModalHandlers } from '../utils/modal.js';
 
 // Expose the i18n helper globally for pages that expect it
 window.updateDynamicContentLanguage = updateDynamicContentLanguage;
@@ -83,7 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
         updateDynamicContentLanguage(modal);
       }
 
-      attachModalClose(modal);
+      attachModalHandlers(modal);
       return modal;
     } catch (err) {
       console.error('Modal load failed:', err);
@@ -91,18 +92,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function attachModalClose(modal) {
-    if (!modal) return;
-    modal.addEventListener('click', (e) => {
-      const target = e.target;
-      // Close when clicking backdrop or elements with data-close
-      if (target === modal || target.classList.contains('modal-overlay') ||
-          target.hasAttribute('data-close')) {
-        modal.classList.remove('active');
-        modal.setAttribute('aria-hidden', 'true');
-      }
-    });
-  }
 
   // Safe utility to dispatch custom events
   function dispatchSafeEvent(name, detail = {}) {
@@ -321,17 +310,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Modals: Close Handler
-  document.querySelectorAll('.modal-overlay').forEach(attachModalClose);
+  document.querySelectorAll('.modal-overlay').forEach(attachModalHandlers);
 
-  // Close active modal on Escape key press
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') {
-      document.querySelectorAll('.modal-overlay.active').forEach(m => {
-        m.classList.remove('active');
-        m.setAttribute('aria-hidden', 'true');
-      });
-    }
-  });
 
   // Sync saved theme
   const savedTheme = localStorage.getItem('theme');

--- a/js/utils/modal.js
+++ b/js/utils/modal.js
@@ -1,0 +1,26 @@
+export function closeModal(modal) {
+  if (!modal) return;
+  modal.classList.remove('active');
+  modal.setAttribute('aria-hidden', 'true');
+}
+
+let escapeHandlerAttached = false;
+
+export function attachModalHandlers(modal) {
+  if (!modal) return;
+  modal.addEventListener('click', (e) => {
+    const target = e.target;
+    if (target === modal || target.classList.contains('modal-overlay') || target.hasAttribute('data-close')) {
+      closeModal(modal);
+    }
+  });
+
+  if (!escapeHandlerAttached) {
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        document.querySelectorAll('.modal-overlay.active').forEach(closeModal);
+      }
+    });
+    escapeHandlerAttached = true;
+  }
+}


### PR DESCRIPTION
## Summary
- add new `modal.js` utility with unified close handling
- use `attachModalHandlers` from `modal.js` in main script
- streamline closing logic for the Contact Us and Join Us modals
- fix closing behavior on Escape

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869d675ebe8832bbb55ce5ba0b09c9c