### PR TITLE
Sync chatbot with language toggle

### DIFF
--- a/js/pages/chatbot.js
+++ b/js/pages/chatbot.js
@@ -24,6 +24,11 @@ function postLanguageToIframe(lang) {
   }
 }
 
+// Allow other modules to push language changes directly
+export function notifyChatbotLanguageChange(lang) {
+  postLanguageToIframe(lang);
+}
+
 // Sync theme with iframe
 function setupThemeSync() {
   if (!chatbotIframe) return;

--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -2,7 +2,7 @@
 
 import { initializeContactModal } from './contact_us.js';
 import { initializeJoinUsModal } from './join_us.js';
-import { initializeChatbotModal } from './chatbot.js';
+import { initializeChatbotModal, notifyChatbotLanguageChange } from './chatbot.js';
 import { updateDynamicContentLanguage } from '../utils/i18n.js';
 import { attachModalHandlers } from '../utils/modal.js';
 
@@ -153,6 +153,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const theme = body.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
     themeButtons.forEach(btn => updateThemeButton(btn, theme, lang));
     dispatchSafeEvent('language-change', { lang });
+    notifyChatbotLanguageChange(lang);
     if (typeof window.updateDynamicContentLanguage === 'function') {
       window.updateDynamicContentLanguage(document);
     }


### PR DESCRIPTION
## Summary
- allow other modules to push language changes to the chatbot
- call new notifier inside the language toggle handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a290c6dcc832bb9061f505bcd1d60