### PR TITLE
Fix: Correct company name to Ops Online Support Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OPS Online Solutions Services Website
+# Ops Online Support Services Website
 
-This repository contains the static website for **OPS Online Solutions Services**. It showcases the company’s business operations, contact center offerings, IT support services and professional staffing solutions.
+This repository contains the static website for **Ops Online Support Services**. It showcases the company’s business operations, contact center offerings, IT support services and professional staffing solutions.
 
 The site is a traditional front-end project with HTML, CSS and JavaScript and is intended to be hosted on any static web platform such as GitHub Pages, Netlify or Cloudflare Pages.
 

--- a/SECURITY_IMPLEMENTATION_NOTES.md
+++ b/SECURITY_IMPLEMENTATION_NOTES.md
@@ -1,6 +1,6 @@
 # Security Implementation Notes
 
-This document summarizes the security enhancements implemented in the OPS Online Solutions Services static website to align with SEO best practices and security guidelines related to PCI DSS, NIST 800, and CISA (from a client-side perspective).
+This document summarizes the security enhancements implemented in the Ops Online Support Services static website to align with SEO best practices and security guidelines related to PCI DSS, NIST 800, and CISA (from a client-side perspective).
 
 ## 1. Search Engine Optimization (SEO)
 


### PR DESCRIPTION
Updated all instances of "OPS Online Solutions Services." to "Ops Online Support Services" in documentation files.