### PR TITLE
Fix favicon path and cache icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- PWA -->
   <link rel="manifest" href="manifest.json">
-  <link rel="icon" href="favicon.ico" type="image/x-icon">
+  <link rel="icon" href="assets/icons/icon-192x192.png" type="image/png">
 </head>
 
 <body>

--- a/js/service-worker.js
+++ b/js/service-worker.js
@@ -6,6 +6,8 @@ const urlsToCache = [
   '/index.html',
   '/offline.html',
   '/manifest.json',
+  '/assets/icons/icon-192x192.png',
+  '/assets/icons/icon-512x512.png',
 
   // Core CSS
   '/css/base/global.css',


### PR DESCRIPTION
## Summary
- link to PNG favicon in index.html instead of missing .ico
- cache icons in service worker for offline use

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d5abed098832bb7a002aeecda042a