### PR TITLE
Remove outer container for chatbot

### DIFF
--- a/mychatbot/chatbot-modal.css
+++ b/mychatbot/chatbot-modal.css
@@ -1,7 +1,7 @@
 /* css/chatbot_modal.css */
 
 /* === Chatbot Modal Container === */
-#chatbot-modal .modal-content {
+#chatbot-modal {
   max-width: 500px;
   width: 95%;
   height: 70vh;
@@ -17,7 +17,7 @@
   transition: all 0.3s ease;
 }
 
-body[data-theme="dark"] #chatbot-modal .modal-content {
+body[data-theme="dark"] #chatbot-modal {
   background-color: #222;
   color: #eee;
   box-shadow: 0 4px 25px rgba(255, 255, 255, 0.05);
@@ -53,7 +53,7 @@ body[data-theme="dark"] #chatbot-modal .modal-footer {
 
 /* === Responsive for Mobile Devices === */
 @media (max-width: 768px) {
-  #chatbot-modal .modal-content {
+  #chatbot-modal {
     /* Override specific height settings to align with global small-screen behavior */
     height: auto;
     max-height: 80vh; /* Or inherit from .modal-content in small-screens.css if preferred */

--- a/mychatbot/chatbot-modal.html
+++ b/mychatbot/chatbot-modal.html
@@ -1,19 +1,17 @@
-<div id="chatbot-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="chatbotModalTitle" tabindex="-1">
-  <div class="modal-content" role="document">
-    <div class="modal-header">
-      <h3 id="chatbotModalTitle" data-en="Chattia" data-es="Chattia">CHATTIA</h3>
-      <button type="button" class="close-modal" data-close aria-label="Close"
-              data-en-label="Close Chatbot Modal"
-              data-es-label="Cerrar Modal de Chatbot">&times;</button>
-    </div>
-    <div class="modal-body" id="chatbot-modal-body">
-      <!-- JS will inject chatbot iframe securely -->
-      <p data-en="Loading chatbot..." data-es="Cargando chatbot...">Loading chatbot...</p>
-    </div>
-    <div class="modal-footer">
-      <button type="button" class="close-modal" data-close data-en="Close" data-es="Cerrar">
-        Close
-      </button>
-    </div>
+<div id="chatbot-modal" class="modal-content" role="dialog" aria-modal="true" aria-labelledby="chatbotModalTitle" tabindex="-1">
+  <div class="modal-header">
+    <h3 id="chatbotModalTitle" data-en="Chattia" data-es="Chattia">CHATTIA</h3>
+    <button type="button" class="close-modal" data-close aria-label="Close"
+            data-en-label="Close Chatbot Modal"
+            data-es-label="Cerrar Modal de Chatbot">&times;</button>
+  </div>
+  <div class="modal-body" id="chatbot-modal-body">
+    <!-- JS will inject chatbot iframe securely -->
+    <p data-en="Loading chatbot..." data-es="Cargando chatbot...">Loading chatbot...</p>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="close-modal" data-close data-en="Close" data-es="Cerrar">
+      Close
+    </button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- simplify `chatbot-modal.html` so the modal content is the root container
- adjust `chatbot-modal.css` selectors for the new structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d6b6f609c832b80106abeaf6a8755