### PR TITLE
Secure: Remove placeholder worker URL from CSP and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,23 @@ When the site is opened directly from the filesystem using `file://`, modals may
 
 ## Customising the Contact Form Endpoint
 
-Form submissions are optionally sent to a Cloudflare Worker. The script `js/pages/contact_us.js` looks for a global variable named `CONTACT_WORKER_URL` and falls back to an empty string if it is not set. Define this variable in the page before the script is loaded, or edit the file directly, to point to your worker:
+The script `js/pages/contact_us.js` looks for a global variable named `CONTACT_WORKER_URL` and falls back to an empty string if it is not set. To enable form submissions, define this variable in the `index.html` page (or whichever page hosts the contact form) before the `contact_us.js` script is loaded. Point it to your configured Cloudflare Worker URL:
 
 ```html
 <script>
-  window.CONTACT_WORKER_URL = "https://your-worker.example.com";
+  // Example:
+  // window.CONTACT_WORKER_URL = "https://your-actual-worker.your-domain.com";
 </script>
 <script type="module" src="js/pages/contact_us.js" defer></script>
 ```
 
-When configured, the form’s data is sent via `POST` to the Worker which should handle the message (for example by sending an email or storing the data). Leaving the value unset disables submissions.
+When `CONTACT_WORKER_URL` is set, the form’s data is sent via `POST` to the specified Worker. This Worker is responsible for handling the message (e.g., sending an email or storing the data). If `CONTACT_WORKER_URL` is not set or is an empty string, submissions will be disabled.
+
+**Important Security Note:** For the contact form to function with a worker, the site administrator must:
+1. Define the `CONTACT_WORKER_URL` global variable with a valid Cloudflare Worker URL.
+2. Add this specific worker URL to the `connect-src` directive of the Content Security Policy (CSP) in `index.html`. The placeholder `https://your-worker.example.com` has been removed from the default CSP.
+
+Failure to correctly configure both the variable and the CSP will prevent the contact form from submitting data to the worker.
 
 ## License
 

--- a/SECURITY_IMPLEMENTATION_NOTES.md
+++ b/SECURITY_IMPLEMENTATION_NOTES.md
@@ -16,14 +16,15 @@ This document summarizes the security enhancements implemented in the Ops Online
 
 CSP has been implemented via `<meta http-equiv="Content-Security-Policy" ...>` tags in all user-facing HTML files:
 
-*   **Main Pages (`index.html`, `about.html`, etc.)**:
+*   **Main Pages (`index.html` specifically, other pages have a stricter CSP)**:
     *   `default-src 'self'`: Restricts loading of resources to the same origin by default.
-*   `script-src 'self' https://cdnjs.cloudflare.com https://www.google.com https://www.gstatic.com https://www.recaptcha.net;`: Allows scripts from self, Font Awesome, and Google (for reCAPTCHA).
-*   `style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com;`: Allows stylesheets from self, Font Awesome, and Google Fonts.
+    *   `script-src 'self' https://cdnjs.cloudflare.com https://www.google.com https://www.gstatic.com https://www.recaptcha.net;`: Allows scripts from self, Font Awesome, and Google (for reCAPTCHA).
+    *   `style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com;`: Allows stylesheets from self, Font Awesome, and Google Fonts.
     *   `img-src 'self' data:`: Allows images from self and data URIs.
     *   `font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com;`: Allows fonts from self, Font Awesome, and Google Fonts.
-    *   `connect-src 'self' https://your-worker.example.com https://firebase.googleapis.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://www.google-analytics.com;`: Allows connections to self (for fetching partials), the contact form worker, and Google services. **Note:** `https://your-worker.example.com` should be replaced.
+    *   `connect-src 'self' https://firebase.googleapis.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://www.google-analytics.com;`: Allows connections to self (for fetching partials) and Google services. For the contact form worker, the administrator must add its specific URL here.
     *   `frame-src 'self' https://www.google.com https://www.recaptcha.net;`: Allows iframes from self (if any are used by non-chatbot features) and Google for reCAPTCHA.
+*   **Other pages (`about.html`, `blog.html`, etc.)** generally use a stricter CSP, e.g., `connect-src 'self';`.
 
 *   **Offline Page (`offline.html`)**:
     *   `default-src 'self'`: Restricts loading of resources to the same origin.
@@ -36,7 +37,9 @@ CSP has been implemented via `<meta http-equiv="Content-Security-Policy" ...>` t
 
 *   CORS is primarily a server-side/hosting configuration concern for a static site.
 *   The Font Awesome CDN and Google reCAPTCHA services are expected to have appropriate CORS headers.
-*   **Action Required**: Configure the Cloudflare Worker (`https://your-worker.example.com`) with CORS headers such as `Access-Control-Allow-Origin: https://www.opsonlinesupport.com` and `Access-Control-Allow-Methods: POST` so that the contact form can send requests securely.
+*   **Action Required for Contact Form**: If a Cloudflare Worker is used for the contact form:
+    1.  The site administrator must add the specific worker URL to the `connect-src` directive of the Content Security Policy in `index.html`. The placeholder `https://your-worker.example.com` has been removed.
+    2.  The Cloudflare Worker itself must be configured with appropriate CORS headers, such as `Access-Control-Allow-Origin: https://www.opsonlinesupport.com` (or the site's actual domain) and `Access-Control-Allow-Methods: POST`, to allow secure requests from the website.
 
 ## 4. PCI DSS, NIST 800, CISA Alignment (Client-Side Best Practices)
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     script-src 'self' https://cdnjs.cloudflare.com https://www.gstatic.com https://www.google.com https://www.recaptcha.net;
     style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com;
     font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com;
-    connect-src 'self' https://your-worker.example.com https://firebase.googleapis.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://www.google-analytics.com;
+    connect-src 'self' https://firebase.googleapis.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://www.google-analytics.com;
     img-src 'self' data:;
     frame-src 'self' https://www.google.com https://www.recaptcha.net;
     object-src 'none';


### PR DESCRIPTION
Removed the placeholder 'https://your-worker.example.com' from the Content Security Policy in index.html.

Updated README.md and SECURITY_IMPLEMENTATION_NOTES.md to:
- Remove references to the placeholder URL in examples.
- Clarify that the site administrator must configure a live worker URL and update the CSP in index.html for the contact form to function.
- Note that index.html has a more permissive CSP for connect-src than other HTML pages in the site to accommodate potential worker integration.