### PR TITLE
Improve FAB menu layering

### DIFF
--- a/css/base/small-screens.css
+++ b/css/base/small-screens.css
@@ -69,6 +69,7 @@
     --mobile-nav-bottom-offset: env(safe-area-inset-bottom, 0px);
     --mobile-nav-vertical-padding: 0.5rem;
     --mobile-nav-estimated-height: 64px;
+    --horizontal-nav-estimated-height: 60px;
   }
 
   .mobile-nav {
@@ -237,7 +238,7 @@
     padding: 0.5rem 1rem; /* Padding from example */
     border-radius: 30px; /* Rounded ends from example */
     box-shadow: 0 4px 8px rgba(0,0,0,0.2); /* From example */
-    z-index: 3000; /* From example */
+    z-index: 3999; /* Ensure above modal overlays */
     transform: scaleX(0);
     transform-origin: right; /* Expand from the right */
     transition: transform 0.3s ease;
@@ -312,13 +313,13 @@
   /* Horizontal Services Submenu specific styles for mobile */
   #horizontalServicesMenu { /* This is .mobile-services-menu in the example */
     position: fixed;
-    bottom: 90px; /* Above the FAB and main nav, from example */
+    bottom: calc(20px + var(--horizontal-nav-estimated-height, 60px) + 10px);
     right: 20px; /* Aligned with the FAB, from example */
     background: var(--bg-current, #fff); /* Use theme variable, fallback to white */
     border: 1px solid var(--border-color-current, #ccc); /* From example */
     padding: 1rem; /* From example */
     display: none; /* Hidden by default, JS toggles .active */
-    z-index: 2000; /* From example */
+    z-index: 3998; /* Just below the horizontal nav */
     border-radius: 10px; /* From example */
     max-height: 50%; /* From example */
     overflow-y: auto; /* From example */


### PR DESCRIPTION
## Summary
- keep FAB nav above modals by raising its z-index
- position horizontal services menu dynamically 10px above the FAB nav

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dc3710be4832bbe2a95be65c11279