### PR TITLE
Fix missing close button on chatbot modal

### DIFF
--- a/html/modals/chatbot_modal.html
+++ b/html/modals/chatbot_modal.html
@@ -41,6 +41,10 @@
           &nbsp;|&nbsp;
           <span id="themeCtrl" class="ctrl">Dark</span>
         </div>
+        <button class="close-modal" data-close aria-label="Close"
+                data-en-label="Close Chatbot" data-es-label="Cerrar Chatbot">
+          &times;
+        </button>
       </div>
       <div id="chat-log" aria-live="polite"></div>
       <div id="chatbot-form-container">


### PR DESCRIPTION
## Summary
- add a close button with proper accessibility labels to the AI chatbot modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e1324aba0832b8ea456a9ddf07e2c