### PR TITLE
Refactor: Standardize modal styles for consistency

### DIFF
--- a/css/modals/contact_center_modal.css
+++ b/css/modals/contact_center_modal.css
@@ -2,24 +2,25 @@
 
 /* === Contact Center Modal Container === */
 #contact-center-modal .modal-content {
-  max-width: 600px;
-  width: 95%;
-  height: auto;
-  margin: 0 auto;
-  background-color: var(--bg-current, #fff);
-  color: var(--text-current, #333);
-  border-radius: 10px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  transition: all 0.3s ease;
+  max-width: 600px; /* Standard */
+  width: 90%; /* Standard from Professionals */
+  height: auto; /* Keep existing */
+  margin: 0 auto; /* Standard from Business Operations & Contact Center */
+  background-color: var(--bg-current, #fff); /* Keep existing */
+  color: var(--text-current, #333); /* Keep existing */
+  border-radius: 12px; /* Standard from Business Operations & Professionals */
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2); /* Standard from Business Operations */
+  padding: 1.5rem; /* Standard from Business Operations & Professionals */
+  display: flex; /* Keep existing */
+  flex-direction: column; /* Keep existing */
+  overflow: hidden; /* Keep existing */
+  transition: all 0.3s ease; /* Keep existing */
 }
 
 body[data-theme="dark"] #contact-center-modal .modal-content {
-  background-color: #222;
-  color: #eee;
-  box-shadow: 0 4px 20px rgba(255, 255, 255, 0.05);
+  background-color: #2a2a2a; /* Align with business_operations_modal.css */
+  color: #eee; /* Keep existing */
+  box-shadow: 0 4px 25px rgba(255, 255, 255, 0.05); /* Align with business_operations_modal.css */
 }
 
 #contact-center-modal .modal-body p:not(:first-child) {
@@ -37,10 +38,14 @@ body[data-theme="dark"] #contact-center-modal .modal-content {
     /* max-width: 100%; */ /* Let global small-screen styles apply */
     /* height: 100%; */ /* Let global small-screen styles apply */
     /* max-height: 100vh; */ /* Let global small-screen styles apply (80vh) */
-    border-radius: 0; /* This can remain if desired */
-    padding: 0; /* This can remain if desired, but base provides padding */
-    border: none; /* This can remain if desired */
-    box-shadow: none; /* This can remain if desired */
+    border-radius: 0; /* This can remain if desired for a specific look */
+    /* padding: 1rem; */ /* Let global small-screen styles apply, or be specific if needed */
+    /* border: none; */ /* Let global small-screen styles apply */
+    /* box-shadow: none; */ /* Let global small-screen styles apply */
   }
+  /* Example of keeping specific padding if needed for this modal, otherwise remove if global is fine */
+  /* #contact-center-modal .modal-content {
+    padding: 1rem;
+  } */
 }
 

--- a/css/modals/it_support_modal.css
+++ b/css/modals/it_support_modal.css
@@ -1,6 +1,22 @@
 /* Modal styles specific to the IT Support modal */
 #it-support-modal .modal-content {
-  max-width: 600px;
+  max-width: 600px; /* Standard */
+  width: 90%; /* Standard from Professionals */
+  margin: 0 auto; /* Standard for centering */
+  background-color: var(--bg-current, #fff); /* Standard */
+  color: var(--text-current, #333); /* Standard */
+  border-radius: 12px; /* Standard from Business Operations & Professionals */
+  padding: 1.5rem; /* Standard from Business Operations & Professionals */
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2); /* Standard from Business Operations */
+  /* transition: all 0.3s ease; */ /* Optional: Add if smooth transition is desired */
+  /* overflow-y: auto; */ /* Optional: Add if content might exceed max-height */
+  /* max-height: 90vh; */ /* Optional: Consistent with Professionals if scrolling is anticipated */
+}
+
+body[data-theme="dark"] #it-support-modal .modal-content {
+  background-color: #2a2a2a; /* Align with business_operations_modal.css */
+  color: #eee; /* Standard dark mode text color */
+  box-shadow: 0 4px 25px rgba(255, 255, 255, 0.05); /* Align with business_operations_modal.css */
 }
 
 #it-support-modal .modal-body p:not(:first-child) {
@@ -9,4 +25,20 @@
 
 #it-support-modal .modal-body ul {
   margin-left: 5px;
+}
+
+/* Responsive design considerations (optional, if not covered by global small-screen styles) */
+@media (max-width: 768px) {
+  #it-support-modal .modal-content {
+    /* width: 100%; */ /* Let global small-screen styles apply */
+    /* max-width: 100%; */ /* Let global small-screen styles apply */
+    /* height: 100%; */ /* Let global small-screen styles apply */
+    /* max-height: 100vh; */ /* Let global small-screen styles apply (e.g., 80vh) */
+    /* border-radius: 0; */ /* Let global small-screen styles apply */
+    /* padding: 1rem; */ /* Adjust if specific padding is needed, else global applies */
+  }
+
+  #it-support-modal .modal-body p {
+    /* font-size: 1rem; */ /* Example: if specific font size for small screens is needed */
+  }
 }


### PR DESCRIPTION
Updated the CSS for 'Centro de Contacto' and 'Soporte IT' modals to align with the styling of 'Business Operations' and 'Professionals' modals.

Specifically, the following properties were standardized for `.modal-content`:
- width
- margin (ensuring `margin: 0 auto;` for centering)
- border-radius
- padding
- box-shadow

Dark mode styles were also harmonized. This change ensures a more consistent look and feel across different service modals.