### PR TITLE
Fix service worker caching and cleanup JS selectors

### DIFF
--- a/js/pages/main.js
+++ b/js/pages/main.js
@@ -99,8 +99,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  const themeButtons = document.querySelectorAll('#fabThemeToggle, #theme-toggle-desktop, #theme-toggle-mobile, #mobile-theme-toggle');
-  const languageButtons = document.querySelectorAll('#fabLanguageToggle, #language-toggle-desktop, #mobile-language-toggle');
+  const themeButtons = document.querySelectorAll('#fabThemeToggle, #theme-toggle-desktop');
+  const languageButtons = document.querySelectorAll('#fabLanguageToggle, #language-toggle-desktop');
 
   function updateThemeButton(btn, theme, lang) {
     if (!btn) return;

--- a/js/service-worker.js
+++ b/js/service-worker.js
@@ -19,7 +19,6 @@ const urlsToCache = [
 
 
   // Core JS
-  '/js/utils/rootPath.js',
   '/js/core/sanitize-input.js',
   '/js/pages/main.js',
 


### PR DESCRIPTION
- Removed non-existent '/js/utils/rootPath.js' from service worker cache list to allow successful installation.
- Cleaned up selectors in `main.js` to remove references to non-existent mobile theme and language toggle button IDs.